### PR TITLE
Model Config Calculation (제안)

### DIFF
--- a/config_sampling.py
+++ b/config_sampling.py
@@ -1,13 +1,14 @@
 import copy
 import random
+from collections import OrderedDict
 
 
-def config_sampling(search_space):
+def config_sampling(search_space: OrderedDict):
     sample = copy.deepcopy(search_space)
 
     # key must be sorted first
     # block type must be sampled first and its arguments later
-    for key in sorted(sample.keys()):
+    for key in sample.keys():
         if not key.endswith('_ARGS'):
             sample[key] = random.sample(sample[key], 1)[0]
         else:
@@ -15,4 +16,23 @@ def config_sampling(search_space):
             sample[key] = config_sampling(sample[key][sample[block_type]])
 
     return sample
+
+
+def complexity(model_config: OrderedDict, 
+               input_shape,
+               mapping_dict: dict):
+    block = None
+    complexity = 0 # FLOPs
+
+    for key in model_config.keys():
+        if block is None:
+            block = model_config[key]
+        else:
+            flops, output_shape = mapping_dict[block](model_config[key], 
+                                                      input_shape)
+            complexity += flops
+            inpuput_shape = output_shape
+            block = None
+
+    return complexity
 

--- a/config_sampling.py
+++ b/config_sampling.py
@@ -31,7 +31,7 @@ def complexity(model_config: OrderedDict,
             flops, output_shape = mapping_dict[block](model_config[key], 
                                                       input_shape)
             complexity += flops
-            inpuput_shape = output_shape
+            input_shape = output_shape
             block = None
 
     return complexity

--- a/config_sampling_test.py
+++ b/config_sampling_test.py
@@ -1,17 +1,18 @@
 import os
 import tensorflow as tf
+from collections import OrderedDict
 from config_sampling import *
 
 
 class ConfigSamplingTest(tf.test.TestCase):
     def test_config_sampling(self):
-        search_space = {
+        search_space = OrderedDict({
             'FIRST': ['A', 'B'],
             'FIRST_ARGS': {
                 'A': {'a': [1, 2, 3]},
                 'B': {'1': [0, 1, 2], '2': [1, 3, 5]},
-            }
-        }
+            },
+        })
 
         sample = config_sampling(search_space)
         self.assertTrue(sample['FIRST'] in search_space['FIRST'])
@@ -20,6 +21,25 @@ class ConfigSamplingTest(tf.test.TestCase):
         for key in sample['FIRST_ARGS'].keys():
             self.assertTrue(sample['FIRST_ARGS'][key] in 
                             search_space['FIRST_ARGS'][sample['FIRST']][key])
+
+    def test_complexity(self):
+        model_config = OrderedDict({
+            'FIRST': 'A', 
+            'FIRST_ARGS': { 'a': 1, },
+            'SECOND': 'B',
+            'SECOND_ARGS': { 'B': 35, 'b': 50 }
+        })
+        input_shape = (32, 32, 3) # without batch dim
+
+        # Mapping Dict
+        # key: block type
+        # value: func(block_args, input_shape) -> FLOPs, output_shape
+        mapping_dict = {
+            'A': lambda c, s: (input_shape[-1]*c['a'], input_shape),
+            'B': lambda c, s: (input_shape[-2]*c['B'] + c['b'], input_shape),
+        }
+
+        self.assertTrue(complexity(model_config, input_shape, mapping_dict) > 0)
 
 
 if __name__ == '__main__':

--- a/feature_extractor.py
+++ b/feature_extractor.py
@@ -163,7 +163,7 @@ def complex_spec(wav: torch.Tensor,
     spec = torchaudio.functional.spectrogram(
         wav, 
         pad=pad, 
-        window=torch.hann_window(win_length,device=device),
+        window=torch.hann_window(win_length, device=device),
         n_fft=n_fft,
         hop_length=hop_length, 
         win_length=win_length, 
@@ -172,7 +172,8 @@ def complex_spec(wav: torch.Tensor,
     return spec
 
 
-def foa_intensity_vectors(complex_specs: torch.Tensor, eps=1e-8) -> torch.Tensor:
+def foa_intensity_vectors(complex_specs: torch.Tensor, 
+                          eps=1e-8) -> torch.Tensor:
     if not torch.is_complex(complex_specs):
         complex_specs = torch.view_as_complex(complex_specs)
 
@@ -283,6 +284,8 @@ if __name__ == '__main__':
                          LABEL_PATH, 
                          LABEL_OUTPUT_PATH,
                          mode='foa', 
+                         win_length=960,
+                         hop_length=480,
                          n_fft=1024)
 
     # Normalizing Extracted Features


### PR DESCRIPTION
각 모델마다 complexity를 대략 계산해야하는데, 계산하는 방식에 대해 제안해봤습니다.

예시를 보여드리자면,
```
model_config = OrderedDict({
    'FIRST': 'A',
    'FIRST_ARGS': { 'a': 1, },
    'SECOND': 'B',
    'SECOND_ARGS': { 'B': 35, 'b': 50 }
})
```
이런식의 model_config가 있으면, 블럭의 종류를 정할 수 있는 파트 (FIRST, SECOND)와 
해당 블럭의 parameter를 넣는 파트 (FIRST_ARGS, SECOND_ARGS)가 번갈아가면서 나오게 짜봤습니다.

해당 model_config의 complexity (FLOP)을 대략 구해야하는데, 이를 구하기 위해서 

`complexity(model_config, input_shape, mapping_dict)
`

를 실행시키면, 바로 구해지는 방식입니다. 
mapping_dict에는 각 블럭 종류별로, 블럭의 parameter들과 input_shape를 입력으로 받아,
FLOPs와 output_shape을 돌려주는 함수들에 매칭시켜주는 dict입니다.

임시 아이디어기 때문에 더 효율적인 아이디어 있으면 언제든지 반영해보겠습니다.
세부적으로 어떻게 complexity를 구할지는 어느정도 방식이 정해지면 틀에 맞춰 구현해보겠습니다.
