### PR TITLE
add complexity + dict_add

### DIFF
--- a/config_sampling_test.py
+++ b/config_sampling_test.py
@@ -1,17 +1,18 @@
 import os
 import tensorflow as tf
+from collections import OrderedDict
 from config_sampling import *
 
 
 class ConfigSamplingTest(tf.test.TestCase):
     def test_config_sampling(self):
-        search_space = {
+        search_space = OrderedDict({
             'FIRST': ['A', 'B'],
             'FIRST_ARGS': {
                 'A': {'a': [1, 2, 3]},
                 'B': {'1': [0, 1, 2], '2': [1, 3, 5]},
-            }
-        }
+            },
+        })
 
         sample = config_sampling(search_space)
         self.assertTrue(sample['FIRST'] in search_space['FIRST'])
@@ -20,6 +21,40 @@ class ConfigSamplingTest(tf.test.TestCase):
         for key in sample['FIRST_ARGS'].keys():
             self.assertTrue(sample['FIRST_ARGS'][key] in 
                             search_space['FIRST_ARGS'][sample['FIRST']][key])
+
+    def test_complexity(self):
+        # complexity calculating functions (for the test)
+        def block_a_complexity(args, input_shape):
+            return {'flop': 2, 'params': 5}, input_shape
+
+        def block_b_complexity(args, input_shape):
+            return {'flop': 7, 'params': 3}, input_shape
+
+        # inputs for complexity (func)
+        model_config = OrderedDict({
+            'FIRST': 'A', 
+            'FIRST_ARGS': { 'a': 1, },
+            'SECOND': 'B',
+            'SECOND_ARGS': { 'B': 35, 'b': 50 }
+        })
+        input_shape = (32, 32, 3) # without batch dim
+        mapping_dict = {
+            'A': block_a_complexity,
+            'B': block_b_complexity,
+        }
+
+        gt = {'flop': 9, 'params': 8}
+        self.assertEqual(
+            gt, complexity(model_config, input_shape, mapping_dict))
+
+    def test_dict_add(self):
+        a = {'a': 3}
+        b = {'a': 2, 'b': 4}
+
+        gt = {'a': 5, 'b': 4}
+
+        c = dict_add(a, b)
+        self.assertEqual(c, gt)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
complexity is for calculating complexity of given model config
dict_add computes addition (this is for complexity)

각 모델마다 complexity를 대략 계산해야하는데, 계산하는 방식에 대해 제안해봤습니다.

예시를 보여드리자면,
```
model_config = OrderedDict({
    'FIRST': 'A',
    'FIRST_ARGS': { 'a': 1, },
    'SECOND': 'B',
    'SECOND_ARGS': { 'B': 35, 'b': 50 }
})
```
이런식의 model_config가 있으면, 블럭의 종류를 정할 수 있는 파트 (FIRST, SECOND)와 
해당 블럭의 parameter를 넣는 파트 (FIRST_ARGS, SECOND_ARGS)가 번갈아가면서 나오게 짜봤습니다.

해당 model_config의 complexity (FLOP)을 대략 구해야하는데, 이를 구하기 위해서 

`complexity(model_config, input_shape, mapping_dict)
`

를 실행시키면, 바로 구해지는 방식입니다. 
mapping_dict에는 각 블럭 종류별로, 블럭의 parameter들과 input_shape를 입력으로 받아,
complexity (FLOP + params + 원하는 수치들) 와 output_shape을 돌려주는 함수들에 매칭시켜주는 dict입니다.
