### PR TITLE
FOA + intensity vectors에 augmentation 적용하기

### DIFF
--- a/transforms.py
+++ b/transforms.py
@@ -32,6 +32,31 @@ def mask(specs, axis, max_mask_size=None, n_mask=1):
     return specs * mask
 
 
+def foa_intensity_vec_aug(x, y):
+    # x : [batch, time, freq, 7]
+    # y : [batch, time, 4*n_classes]
+    x = tf.identity(x)
+    y = tf.identity(y)
+    # [batch, time, 4*n_classes] to [batch, time, 4, n_classes]
+    y = tf.reshape(y, [*y.shape[:-1]] + [4, -1]) 
+
+    intensity_vectors = x[..., -3:]
+    cartesian = y[..., -3:, :]
+
+    batch = x.shape[0]
+    flip = tf.random.uniform([batch, 3], 0, 2, dtype=tf.int32)
+    flip = tf.cast(flip, 'float32')
+
+    intensity_vectors = (1 - 2*tf.reshape(flip, (-1, 1, 1, 3))) * intensity_vectors 
+    cartesian = (1 - 2*tf.reshape(flip, (-1, 1, 3, 1))) * cartesian 
+
+    x = tf.concat([x[..., :-3], intensity_vectors], axis=-1)
+    y = tf.concat([y[..., :-3, :], cartesian], axis=-2)
+    y = tf.reshape(y, [*y.shape[:-2]] + [4*y.shape[-1]])
+
+    return x, y
+
+
 def split_total_labels_to_sed_doa(x, y):
     n_classes = tf.shape(y)[-1] // 4
     return x, (y[..., :n_classes], y[..., n_classes:])

--- a/transforms.py
+++ b/transforms.py
@@ -38,13 +38,12 @@ def foa_intensity_vec_aug(x, y):
     x = tf.identity(x)
     y = tf.identity(y)
     # [batch, time, 4*n_classes] to [batch, time, 4, n_classes]
-    y = tf.reshape(y, [*y.shape[:-1]] + [4, -1]) 
+    y = tf.reshape(y, [-1] + [*y.shape[1:-1]] + [4, y.shape[-1]//4])
 
     intensity_vectors = x[..., -3:]
     cartesian = y[..., -3:, :]
 
-    batch = x.shape[0]
-    flip = tf.random.uniform([batch, 3], 0, 2, dtype=tf.int32)
+    flip = tf.random.uniform([tf.shape(x)[0], 3], 0, 2, dtype=tf.int32)
     flip = tf.cast(flip, 'float32')
 
     intensity_vectors = (1 - 2*tf.reshape(flip, (-1, 1, 1, 3))) * intensity_vectors 
@@ -52,7 +51,7 @@ def foa_intensity_vec_aug(x, y):
 
     x = tf.concat([x[..., :-3], intensity_vectors], axis=-1)
     y = tf.concat([y[..., :-3, :], cartesian], axis=-2)
-    y = tf.reshape(y, [*y.shape[:-2]] + [4*y.shape[-1]])
+    y = tf.reshape(y, [-1] + [*y.shape[1:-2]] + [4*y.shape[-1]])
 
     return x, y
 

--- a/transforms_test.py
+++ b/transforms_test.py
@@ -29,6 +29,28 @@ class TransformsTest(tf.test.TestCase):
         self.assertAllEqual(target, 
                             mask(org, axis=1, max_mask_size=3, n_mask=2))
 
+    def test_intensity_vec_aug(self):
+        tf.random.set_seed(2022)
+        x_size = (1, 10, 32, 7) # [batch, time, freq, 7]
+        y_size = (1, 2, 12) # [batch, time, n_classes*4]
+        x = tf.random.uniform(x_size)
+        y = tf.random.uniform(y_size) 
+
+        # test output shapes
+        new_x, new_y = foa_intensity_vec_aug(x, y)
+        self.assertAllEqual(x.shape, x_size)
+        self.assertAllEqual(y.shape, y_size)
+
+        # test whether x and y are fliped equally
+        x_flip = x[..., -3:] != new_x[..., -3:]
+        x_flip = tf.reduce_mean(tf.cast(x_flip, 'float32'), axis=(1, 2))
+
+        y_flip = tf.reshape(y, y_size[:-1]+(4, -1))[..., -3:, :] \
+                != tf.reshape(new_y, y_size[:-1]+(4, -1))[..., -3:, :]
+        y_flip = tf.reduce_mean(tf.cast(y_flip, 'float32'), axis=(1, 3))
+
+        self.assertAllEqual(x_flip, y_flip)
+
     def test_split_total_labels_to_sed_doa(self):
         batch, time, n_classes = 32, 10, 14
         y = tf.zeros((batch, time, n_classes * 4))


### PR DESCRIPTION
foa_intensity_vec_aug라는 이름의 함수를 넣었습니다.
사용할 때는 seldnet_data_to_dataloader 함수에서 batch_transforms 넣을 때
split_total_labels_to_sed_doa 이전에 넣으면 됩니다. 즉

```
batch_transforms = [split_total_labels_to_sed_doa]
if mode == 'train':
    batch_transforms.insert(0, foa_intensity_vec_aug)
```

이런식으로 split_total_labels_to_sed_doa 전에 실행하게 하면 됩니다.

resolved: #70 