### PR TITLE
Complexity 계산하기

### DIFF
--- a/complexity.py
+++ b/complexity.py
@@ -4,7 +4,46 @@
 # 
 # references
 # https://github.com/facebookresearch/pycls/blob/master/pycls/models/blocks.py
+from utils import dict_add
 
+def res_bottleneck_block_complexity(model_config, input_shape):
+    # mandatory parameters
+    filters = model_config['filters']
+    strides = model_config['strides']
+    groups = model_config['groups']
+    bottleneck_ratio = model_config['bottleneck_ratio']
+
+    stries = safe_tuple(strides, 2)
+    btn_size = int(filters * bottleneck_ratio)
+
+    # calculate
+    complexity = {}
+    output_shape, cx = conv2d_complexity(input_shape, btn_size, 1)
+    complexity = dict_add(complexity, cx)
+    output_shape, cx = norm_complexity(output_shape)
+    complexity = dict_add(complexity, cx)
+
+    output_shape, cx = conv2d_complexity(
+        output_shape, btn_size, 3, strides, groups)
+    complexity = dict_add(complexity, cx)
+    output_shape, cx = norm_complexity(output_shape)
+    complexity = dict_add(complexity, cx)
+
+    output_shape, cx = conv2d_complexity(output_shape, filters, 1)
+    complexity = dict_add(complexity, cx)
+    output_shape, cx = norm_complexity(output_shape)
+    complexity = dict_add(complexity, cx)
+
+    if strides != (1, 1) or inputs.shape[-1] != filters:
+        output_shape, cx = conv2d_complexity(input_shape, filters, 1, strides)
+        complexity = dict_add(complexity, cx)
+        output_shape, cx = norm_complexity(output_shape)
+        complexity = dict_add(complexity, cx)
+
+    return complexity, output_shape
+
+
+# basic complexity
 def conv2d_complexity(input_shape: list, 
                       filters,
                       kernel_size,

--- a/complexity.py
+++ b/complexity.py
@@ -1,0 +1,70 @@
+# COMPLEXITY
+# 1. assume the last dim is channel dim
+# 2. batch dim must be excluded from input_shape
+# 
+# references
+# https://github.com/facebookresearch/pycls/blob/master/pycls/models/blocks.py
+
+def conv2d_complexity(input_shape: list, 
+                      filters,
+                      kernel_size,
+                      strides=(1, 1),
+                      groups=1,
+                      use_bias=True):
+    kernel_size = safe_tuple(kernel_size, 2)
+    strides = safe_tuple(strides, 2)
+
+    h, w, c = input_shape[-3:]
+    h, w = (h-1)//strides[0] + 1, (w-1)//strides[1] + 1
+    new_shape = input_shape[:-3] + [h, w, filters]
+
+    kernel = kernel_size[0] * kernel_size[1]
+    flops = kernel * c * filters * h * w // groups
+    params = kernel * c * filters // groups
+    if use_bias:
+        flops += filters 
+        params += filters
+
+    return new_shape, {'flops': flops, 'params': params}
+
+
+def norm_complexity(input_shape, center=True, scale=True):
+    return input_shape, {'params': input_shape[-1] * (center + scale)}
+
+
+def pool2d_complexity(input_shape,
+                      pool_size,
+                      strides=1):
+    strides = safe_tuple(strides, 2)
+
+    h, w, c = input_shape[-3:]
+    h, w = (h-1)//strides[0] + 1, (w-1)//strides[1] + 1
+    new_shape = input_shape[:-3] + [h, w, c]
+    return new_shape, {}
+
+
+def linear_complexity(input_shape, units, use_bias=True):
+    c = input_shape[-1]
+    new_shape = input_shape[:-1] + [units]
+
+    size = 1
+    for s in input_shape[:-1]:
+        size *= s
+
+    flops = (s + use_bias) * c * units
+    params = (c + use_bias) * units
+    return new_shape, {'flops': flops, 'params': params}
+
+
+# utils
+def safe_tuple(tuple_or_scalar, length=2):
+    if isinstance(tuple_or_scalar, (int, float)):
+        tuple_or_scalar = (tuple_or_scalar, ) * length
+    elif isinstance(tuple_or_scalar, (list, tuple)):
+        count = len(tuple_or_scalar)
+        if count == 1:
+            tuple_or_scalar = tuple_or_scalar * length
+        elif count != length:
+            raise ValueError("length of input must be one or required length")
+    return tuple_or_scalar
+

--- a/complexity.py
+++ b/complexity.py
@@ -93,7 +93,7 @@ def linear_complexity(input_shape, units, use_bias=True, prev_cx=None):
     for s in input_shape[:-1]:
         size *= s
 
-    flops = (s + use_bias) * c * units
+    flops = size * (c + use_bias) * units
     params = (c + use_bias) * units
     complexity = dict_add(
         {'flops': flops, 'params': params},

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -4,6 +4,18 @@ from complexity import *
 
 
 class ComplexityTest(tf.test.TestCase):
+    def test_res_bottleneck_block_complexity(self):
+        model_config = {
+            'filters': 32,
+            'strides': 2,
+            'groups': 2,
+            'bottleneck_ratio': 2
+        }
+        input_shape = [32, 32, 16]
+        self.assertEqual(
+            res_bottleneck_block_complexity(model_config, input_shape),
+            ({'flops': 6422720, 'params': 22592}, [16, 16, 32]))
+
     def test_conv2d_complexity(self):
         self.assertEqual(
             conv2d_complexity(input_shape=[32, 32, 3],

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -22,28 +22,28 @@ class ComplexityTest(tf.test.TestCase):
                               filters=16,
                               kernel_size=3,
                               strides=1),
-            ([32, 32, 16], {'flops': 442384, 'params': 448}))
+            ({'flops': 442384, 'params': 448}, [32, 32, 16]))
 
     def test_norm_complexity(self):
         self.assertEqual(
             norm_complexity(input_shape=[32, 32, 3],
                               center=True,
                               scale=True),
-            ([32, 32, 3], {'params': 6}))
+            ({'params': 6}, [32, 32, 3]))
 
     def test_pool2d_complexity(self):
         self.assertEqual(
             pool2d_complexity(input_shape=[32, 32, 3],
                                pool_size=3,
                                strides=(2, 1)),
-            ([16, 32, 3], {}))
+            ({}, [16, 32, 3]))
 
     def test_linear_complexity(self):
         self.assertEqual(
             linear_complexity(input_shape=[1, 512],
                               units=1024,
                               use_bias=True),
-            ([1, 1024], {'flops': 1048576, 'params': 525312}))
+            ({'flops': 1048576, 'params': 525312}, [1, 1024]))
 
     def test_safe_tuple(self):
         self.assertEqual((1, 1), safe_tuple(1, 2))

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -1,0 +1,46 @@
+import os
+import tensorflow as tf
+from complexity import *
+
+
+class ComplexityTest(tf.test.TestCase):
+    def test_conv2d_complexity(self):
+        self.assertEqual(
+            conv2d_complexity(input_shape=[32, 32, 3],
+                              filters=16,
+                              kernel_size=3,
+                              strides=1),
+            ([32, 32, 16], {'flops': 442384, 'params': 448}))
+
+    def test_norm_complexity(self):
+        self.assertEqual(
+            norm_complexity(input_shape=[32, 32, 3],
+                              center=True,
+                              scale=True),
+            ([32, 32, 3], {'params': 6}))
+
+    def test_pool2d_complexity(self):
+        self.assertEqual(
+            pool2d_complexity(input_shape=[32, 32, 3],
+                               pool_size=3,
+                               strides=(2, 1)),
+            ([16, 32, 3], {}))
+
+    def test_linear_complexity(self):
+        self.assertEqual(
+            linear_complexity(input_shape=[1, 512],
+                              units=1024,
+                              use_bias=True),
+            ([1, 1024], {'flops': 1048576, 'params': 525312}))
+
+    def test_safe_tuple(self):
+        self.assertEqual((1, 1), safe_tuple(1, 2))
+        self.assertEqual((1, 3), safe_tuple((1, 3), 2))
+        with self.assertRaises(ValueError):
+            safe_tuple((1, 2, 3), 2)
+
+
+if __name__ == '__main__':
+    os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
+    tf.test.main()
+

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -70,16 +70,16 @@ class ComplexityTest(tf.test.TestCase):
             (dict_add(target_cx, self.prev_cx), target_shape))
 
     def test_linear_complexity(self):
-        target_cx = {'flops': 1048576, 'params': 525312}
-        target_shape = [1, 1024]
+        target_cx = {'flops': 1050624, 'params': 525312}
+        target_shape = [2, 1024]
 
         self.assertEqual(
-            linear_complexity(input_shape=[1, 512],
+            linear_complexity(input_shape=[2, 512],
                               units=1024,
                               use_bias=True),
             (target_cx, target_shape))
         self.assertEqual(
-            linear_complexity(input_shape=[1, 512],
+            linear_complexity(input_shape=[2, 512],
                               units=1024,
                               use_bias=True,
                               prev_cx=self.prev_cx),

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -4,6 +4,9 @@ from complexity import *
 
 
 class ComplexityTest(tf.test.TestCase):
+    def setUp(self):
+        self.prev_cx = {'flops': 456, 'params': 123}
+
     def test_res_bottleneck_block_complexity(self):
         model_config = {
             'filters': 32,
@@ -17,33 +20,70 @@ class ComplexityTest(tf.test.TestCase):
             ({'flops': 6422720, 'params': 22592}, [16, 16, 32]))
 
     def test_conv2d_complexity(self):
+        target_cx = {'flops': 442384, 'params': 448}
+        target_shape = [32, 32, 16]
+
         self.assertEqual(
             conv2d_complexity(input_shape=[32, 32, 3],
                               filters=16,
                               kernel_size=3,
                               strides=1),
-            ({'flops': 442384, 'params': 448}, [32, 32, 16]))
+            (target_cx, target_shape))
+        self.assertEqual(
+            conv2d_complexity(input_shape=[32, 32, 3],
+                              filters=16,
+                              kernel_size=3,
+                              strides=1,
+                              prev_cx=self.prev_cx),
+            (dict_add(target_cx, self.prev_cx), target_shape))
 
     def test_norm_complexity(self):
+        target_cx = {'params': 6}
+        target_shape = [32, 32, 3]
+
         self.assertEqual(
             norm_complexity(input_shape=[32, 32, 3],
-                              center=True,
-                              scale=True),
-            ({'params': 6}, [32, 32, 3]))
+                            center=True,
+                            scale=True),
+            (target_cx, target_shape))
+        self.assertEqual(
+            norm_complexity(input_shape=[32, 32, 3],
+                            center=True,
+                            scale=True,
+                            prev_cx=self.prev_cx),
+            (dict_add(target_cx, self.prev_cx), target_shape))
 
     def test_pool2d_complexity(self):
+        target_cx = {}
+        target_shape = [16, 32, 3]
+
         self.assertEqual(
             pool2d_complexity(input_shape=[32, 32, 3],
-                               pool_size=3,
-                               strides=(2, 1)),
-            ({}, [16, 32, 3]))
+                              pool_size=3,
+                              strides=(2, 1)),
+            (target_cx, target_shape))
+        self.assertEqual(
+            pool2d_complexity(input_shape=[32, 32, 3],
+                              pool_size=3,
+                              strides=(2, 1),
+                              prev_cx=self.prev_cx),
+            (dict_add(target_cx, self.prev_cx), target_shape))
 
     def test_linear_complexity(self):
+        target_cx = {'flops': 1048576, 'params': 525312}
+        target_shape = [1, 1024]
+
         self.assertEqual(
             linear_complexity(input_shape=[1, 512],
                               units=1024,
                               use_bias=True),
-            ({'flops': 1048576, 'params': 525312}, [1, 1024]))
+            (target_cx, target_shape))
+        self.assertEqual(
+            linear_complexity(input_shape=[1, 512],
+                              units=1024,
+                              use_bias=True,
+                              prev_cx=self.prev_cx),
+            (dict_add(target_cx, self.prev_cx), target_shape))
 
     def test_safe_tuple(self):
         self.assertEqual((1, 1), safe_tuple(1, 2))

--- a/config_sampling.py
+++ b/config_sampling.py
@@ -1,6 +1,5 @@
 import copy
 import random
-from functools import reduce
 from collections import OrderedDict
 
 
@@ -48,72 +47,4 @@ def dict_add(first: dict, second: dict):
             output[key] = second[key]
 
     return output
-
-
-def safe_tuple(tuple_or_scalar, length=2):
-    if isinstance(tuple_or_scalar, (int, float)):
-        tuple_or_scalar = (tuple_or_scalar, ) * length
-    elif isinstance(tuple_or_scalar, (list, tuple)):
-        count = len(tuple_or_scalar)
-        if count == 1:
-            tuple_or_scalar = tuple_or_scalar * length
-        elif count != length:
-            raise ValueError("length of input must be one or required length")
-    return tuple_or_scalar
-
-
-# COMPLEXITY
-# 1. assume the last dim is channel dim
-# 2. batch dim must be excluded from input_shape
-# 
-# https://github.com/facebookresearch/pycls/blob/master/pycls/models/blocks.py
-def conv2d_complexity(input_shape: list, 
-                      filters,
-                      kernel_size,
-                      strides=(1, 1),
-                      groups=1,
-                      use_bias=True):
-    kernel_size = safe_tuple(kernel_size, 2)
-    strides = safe_tuple(strides, 2)
-
-    h, w, c = input_shape[-3:]
-    h, w = (h-1)//strides[0] + 1, (w-1)//strides[1] + 1
-    new_shape = input_shape[:-3] + [h, w, filters]
-
-    kernel = kernel_size[0] * kernel_size[1]
-    flops = kernel * c * filters * h * w // groups
-    params = kernel * c * filters // groups
-    if use_bias:
-        flops += filters 
-        params += filters
-
-    return new_shape, {'flops': flops, 'params': params}
-
-
-def norm_complexity(input_shape, center=True, scale=True):
-    return input_shape, {'params': input_shape[-1] * (center + scale)}
-
-
-def pool2d_complexity(input_shape,
-                      pool_size,
-                      strides=1):
-    strides = safe_tuple(strides, 2)
-
-    h, w, c = input_shape[-3:]
-    h, w = (h-1)//strides[0] + 1, (w-1)//strides[1] + 1
-    new_shape = input_shape[:-3] + [h, w, c]
-    return new_shape, {}
-
-
-def linear_complexity(input_shape, units, use_bias=True):
-    c = input_shape[-1]
-    new_shape = input_shape[:-1] + [units]
-
-    size = 1
-    for s in input_shape[:-1]:
-        size *= s
-
-    flops = (s + use_bias) * c * units
-    params = (c + use_bias) * units
-    return new_shape, {'flops': flops, 'params': params}
 

--- a/config_sampling.py
+++ b/config_sampling.py
@@ -1,5 +1,6 @@
 import copy
 import random
+from functools import reduce
 from collections import OrderedDict
 
 
@@ -47,4 +48,72 @@ def dict_add(first: dict, second: dict):
             output[key] = second[key]
 
     return output
+
+
+def safe_tuple(tuple_or_scalar, length=2):
+    if isinstance(tuple_or_scalar, (int, float)):
+        tuple_or_scalar = (tuple_or_scalar, ) * length
+    elif isinstance(tuple_or_scalar, (list, tuple)):
+        count = len(tuple_or_scalar)
+        if count == 1:
+            tuple_or_scalar = tuple_or_scalar * length
+        elif count != length:
+            raise ValueError("length of input must be one or required length")
+    return tuple_or_scalar
+
+
+# COMPLEXITY
+# 1. assume the last dim is channel dim
+# 2. batch dim must be excluded from input_shape
+# 
+# https://github.com/facebookresearch/pycls/blob/master/pycls/models/blocks.py
+def conv2d_complexity(input_shape: list, 
+                      filters,
+                      kernel_size,
+                      strides=(1, 1),
+                      groups=1,
+                      use_bias=True):
+    kernel_size = safe_tuple(kernel_size, 2)
+    strides = safe_tuple(strides, 2)
+
+    h, w, c = input_shape[-3:]
+    h, w = (h-1)//strides[0] + 1, (w-1)//strides[1] + 1
+    new_shape = input_shape[:-3] + [h, w, filters]
+
+    kernel = kernel_size[0] * kernel_size[1]
+    flops = kernel * c * filters * h * w // groups
+    params = kernel * c * filters // groups
+    if use_bias:
+        flops += filters 
+        params += filters
+
+    return new_shape, {'flops': flops, 'params': params}
+
+
+def norm_complexity(input_shape, center=True, scale=True):
+    return input_shape, {'params': input_shape[-1] * (center + scale)}
+
+
+def pool2d_complexity(input_shape,
+                      pool_size,
+                      strides=1):
+    strides = safe_tuple(strides, 2)
+
+    h, w, c = input_shape[-3:]
+    h, w = (h-1)//strides[0] + 1, (w-1)//strides[1] + 1
+    new_shape = input_shape[:-3] + [h, w, c]
+    return new_shape, {}
+
+
+def linear_complexity(input_shape, units, use_bias=True):
+    c = input_shape[-1]
+    new_shape = input_shape[:-1] + [units]
+
+    size = 1
+    for s in input_shape[:-1]:
+        size *= s
+
+    flops = (s + use_bias) * c * units
+    params = (c + use_bias) * units
+    return new_shape, {'flops': flops, 'params': params}
 

--- a/config_sampling.py
+++ b/config_sampling.py
@@ -2,6 +2,8 @@ import copy
 import random
 from collections import OrderedDict
 
+from utils import dict_add
+
 
 def config_sampling(search_space: OrderedDict):
     sample = copy.deepcopy(search_space)
@@ -35,16 +37,4 @@ def complexity(model_config: OrderedDict,
             block = None
 
     return total_complexity
-
-
-def dict_add(first: dict, second: dict):
-    output = copy.deepcopy(first)
-
-    for key in second.keys():
-        if key in output:
-            output[key] += second[key]
-        else:
-            output[key] = second[key]
-
-    return output
 

--- a/config_sampling_test.py
+++ b/config_sampling_test.py
@@ -47,15 +47,6 @@ class ConfigSamplingTest(tf.test.TestCase):
         self.assertEqual(
             gt, complexity(model_config, input_shape, mapping_dict))
 
-    def test_dict_add(self):
-        a = {'a': 3}
-        b = {'a': 2, 'b': 4}
-
-        gt = {'a': 5, 'b': 4}
-
-        c = dict_add(a, b)
-        self.assertEqual(c, gt)
-
 
 if __name__ == '__main__':
     os.environ['CUDA_VISIBLE_DEVICES'] = '-1'

--- a/config_sampling_test.py
+++ b/config_sampling_test.py
@@ -56,41 +56,6 @@ class ConfigSamplingTest(tf.test.TestCase):
         c = dict_add(a, b)
         self.assertEqual(c, gt)
 
-    def test_safe_tuple(self):
-        self.assertEqual((1, 1), safe_tuple(1, 2))
-        self.assertEqual((1, 3), safe_tuple((1, 3), 2))
-        with self.assertRaises(ValueError):
-            safe_tuple((1, 2, 3), 2)
-
-    def test_conv2d_complexity(self):
-        self.assertEqual(
-            conv2d_complexity(input_shape=[32, 32, 3],
-                              filters=16,
-                              kernel_size=3,
-                              strides=1),
-            ([32, 32, 16], {'flops': 442384, 'params': 448}))
-
-    def test_norm_complexity(self):
-        self.assertEqual(
-            norm_complexity(input_shape=[32, 32, 3],
-                              center=True,
-                              scale=True),
-            ([32, 32, 3], {'params': 6}))
-
-    def test_pool2d_complexity(self):
-        self.assertEqual(
-            pool2d_complexity(input_shape=[32, 32, 3],
-                               pool_size=3,
-                               strides=(2, 1)),
-            ([16, 32, 3], {}))
-
-    def test_linear_complexity(self):
-        self.assertEqual(
-            linear_complexity(input_shape=[1, 512],
-                              units=1024,
-                              use_bias=True),
-            ([1, 1024], {'flops': 1048576, 'params': 525312}))
-
 
 if __name__ == '__main__':
     os.environ['CUDA_VISIBLE_DEVICES'] = '-1'

--- a/modules.py
+++ b/modules.py
@@ -124,7 +124,7 @@ def res_bottleneck_block(model_config: dict):
     bottleneck_size = int(filters * bottleneck_ratio)
 
     def bottleneck_block(inputs):
-        out = Conv2D(filters, 1)(inputs)
+        out = Conv2D(bottleneck_size, 1)(inputs)
         out = BatchNormalization()(out)
         out = Activation(activation)(out)
 

--- a/modules.py
+++ b/modules.py
@@ -138,6 +138,7 @@ def res_bottleneck_block(model_config: dict):
 
         if strides != (1, 1) or inputs.shape[-1] != filters:
             inputs = Conv2D(filters, 1, strides)(inputs)
+            inputs = BatchNormalization()(inputs)
         
         out = Activation(activation)(out + inputs)
 

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,6 @@
+import copy
 import tensorflow as tf
+
 
 class CustomSchedule(tf.keras.optimizers.schedules.LearningRateSchedule):
     def __init__(self, d_model, decay):
@@ -17,6 +19,18 @@ class CustomSchedule(tf.keras.optimizers.schedules.LearningRateSchedule):
 def safe_div(x, y, eps=1e-8):
     # returns safe x / max(y, epsilon)
     return x / tf.maximum(y, eps)
+
+
+def dict_add(first: dict, second: dict):
+    output = copy.deepcopy(first)
+
+    for key in second.keys():
+        if key in output:
+            output[key] += second[key]
+        else:
+            output[key] = second[key]
+
+    return output
 
 
 def get_device():

--- a/utils_test.py
+++ b/utils_test.py
@@ -1,0 +1,14 @@
+import os
+import tensorflow as tf
+from utils import *
+
+
+class UtilsTest(tf.test.TestCase):
+    def test_safe_div(self):
+        self.assertFalse(tf.math.is_nan(safe_div(1, 0.)))
+
+
+if __name__ == '__main__':
+    os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
+    tf.test.main()
+

--- a/utils_test.py
+++ b/utils_test.py
@@ -7,6 +7,15 @@ class UtilsTest(tf.test.TestCase):
     def test_safe_div(self):
         self.assertFalse(tf.math.is_nan(safe_div(1, 0.)))
 
+    def test_dict_add(self):
+        a = {'a': 3}
+        b = {'a': 2, 'b': 4}
+
+        gt = {'a': 5, 'b': 4}
+
+        c = dict_add(a, b)
+        self.assertEqual(c, gt)
+
 
 if __name__ == '__main__':
     os.environ['CUDA_VISIBLE_DEVICES'] = '-1'


### PR DESCRIPTION
모델의 complexity를 계산하는 방법을 제시해봤습니다.

기본적으로 complexity를 계산할 수 있는 conv2d_complexity, norm_complexity, pool2d_complexity,
linear_complexity를 만들었습니다.

이 기본적인 연산으로 기본 블럭 삼아서 연산하시면 됩니다. 예시로 res_bottleneck_block을 기준으로
구현해봤습니다. 기본적으로 기존 블럭 구현 코드 가져와서, 살짝 맞게 바꾸시면 됩니다.
이 방식이 확정이 아닐수 있어서, 일단 한 모듈만 구현해서 공유합니다. 
머지되면, 추후에 다른 공개된 모델들도 적용해보겠습니다.

테스트 파일도 첨부하였습니다. 더 좋은 아이디어 있으면 언제든지 알려주시고 반영해보도록 하겠습니다.
지금은 params, flops로 하였지만, 다른 것도 추후에 더 첨부할 수 있습니다.