### PR TITLE
add get_xyz_swap to aid FOA channel swapping

### DIFF
--- a/transforms.py
+++ b/transforms.py
@@ -60,3 +60,22 @@ def split_total_labels_to_sed_doa(x, y):
     n_classes = tf.shape(y)[-1] // 4
     return x, (y[..., :n_classes], y[..., n_classes:])
 
+
+''' For FOA Channel Swapping '''
+T_XYZ_TO_YZX = tf.convert_to_tensor(
+    [[0., 1., 0.],
+     [0., 0., 1.],
+     [1., 0., 0.]])
+
+T_XYZ_TO_YZX_INV = tf.convert_to_tensor(
+    [[0., 0., 1.],
+     [1., 0., 0.],
+     [0., 1., 0.]])
+
+I3 = tf.eye(3, dtype='float32')
+
+def get_xyz_swap(yzx_swap):
+    B = tf.gather(I3, yzx_swap)
+    A = tf.matmul(tf.matmul(T_XYZ_TO_YZX_INV, B), T_XYZ_TO_YZX)
+    return tf.argmax(A, -1)
+

--- a/transforms_test.py
+++ b/transforms_test.py
@@ -61,7 +61,28 @@ class TransformsTest(tf.test.TestCase):
         self.assertAllEqual(doa.shape,
                             [batch, time, n_classes*3])
 
+    def test_xyz_swap(self):
+        xyz = [2, 3, 5]
+        yzx = [3, 5, 2]
+
+        swaps = tf.convert_to_tensor(
+            [[0, 1, 2],
+             [0, 2, 1],
+             [1, 0, 2],
+             [1, 2, 0],
+             [2, 0, 1],
+             [2, 1, 0]])
+
+        for yzx_swap in swaps:
+            xyz_swap = get_xyz_swap(yzx_swap)
+
+            new_xyz = tf.gather(xyz, xyz_swap)
+            new_yzx = tf.gather(yzx, yzx_swap)
+
+            self.assertAllEqual(new_xyz, [new_yzx[-1], *new_yzx[:-1]])
+
 
 if __name__ == '__main__':
     os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
     tf.test.main()
+


### PR DESCRIPTION
사용법은 yzx에서 즉 H1, H2, H3에서 perm을 일단 shuffle을 통해서 생성하고,
그 생성된 perm을 xyz_perm = get_xyz_swap(perm)처럼 함수를 통과시키게 되면
intensity vector, label 등에 xyz_perm으로 gather하면 됩니다.

불필요한 계산을 줄이기 위해 고정된 상수들은 미리 계산하여 transforms.py에 대문자로 저장하였습니다.
