### PR TITLE
GRU, attention complexity 추가

### DIFF
--- a/complexity.py
+++ b/complexity.py
@@ -30,7 +30,7 @@ def res_bottleneck_block_complexity(model_config, input_shape):
     cx, output_shape = conv2d_complexity(output_shape, filters, 1, prev_cx=cx)
     cx, output_shape = norm_complexity(output_shape, prev_cx=cx)
 
-    if strides != (1, 1) or inputs.shape[-1] != filters:
+    if strides != (1, 1) or input_shape[-1] != filters:
         cx, output_shape = conv2d_complexity(input_shape, filters, 1, strides, 
                                              prev_cx=cx)
         cx, output_shape = norm_complexity(output_shape, prev_cx=cx)
@@ -101,7 +101,7 @@ def linear_complexity(input_shape, units, use_bias=True, prev_cx=None):
     return complexity, output_shape
 
 
-def GRU_complexity(input_shape, units, use_bias=True,
+def gru_complexity(input_shape, units, use_bias=True,
                    bi=True, prev_cx=None):
     
     input_chan = input_shape[-1]
@@ -125,8 +125,10 @@ def GRU_complexity(input_shape, units, use_bias=True,
 
 
 # It only assume self attention
-def attention_complexity(input_shape, num_heads, key_dim, value_dim=None,
-                         use_bias=True, prev_cx=None):
+def multi_head_attention_complexity(input_shape, num_heads, key_dim, 
+                                   value_dim=None,
+                                   use_bias=True, 
+                                   prev_cx=None):
     
     c = input_shape[-1]
     size = 1

--- a/complexity.py
+++ b/complexity.py
@@ -160,10 +160,10 @@ def Attention_complexity(input_shape, num_heads, key_dim, value_dim,
         size *= s
     
     # making Q, K, V
-    params = num_heads*c*((key_dim + use_bias)*2 + value_dim + use_bias)
+    params = num_heads*(c + use_bias)*(key_dim*2 + value_dim)
     
     # Value to output
-    params += num_heads*c*(value_dim + use_bias)
+    params += num_heads*c*value_dim + c*use_bias
 
     # embedding
     flops = size*num_heads*(2*use_bias + 2*key_dim + value_dim)*c

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -86,19 +86,17 @@ class ComplexityTest(tf.test.TestCase):
             (dict_add(target_cx, self.prev_cx), target_shape))
 
     def test_GRU_complexity(self):
-        target_cx = {'flops': 2676000, 'params': 9360}
+        target_cx = {'flops': 978000, 'params': 9360}
         target_shape = [32, 100, 30]
         self.assertEqual(
             GRU_complexity(input_shape=[32, 100, 20],
                            units=30,
-                           layers=2,
                            use_bias=True,
                            bi=True),
             (target_cx, target_shape))
         self.assertEqual(
             GRU_complexity(input_shape=[32, 100, 20],
                            units=30,
-                           layers=2,
                            use_bias=True,
                            bi=True,
                            prev_cx=self.prev_cx),
@@ -109,14 +107,14 @@ class ComplexityTest(tf.test.TestCase):
         target_cx = {'flops': 109465600, 'params': 790656}
         target_shape = [1, 100, 128]
         self.assertEqual(
-            Attention_complexity(input_shape=[1, 100, 128],
+            attention_complexity(input_shape=[1, 100, 128],
                                  num_heads=4,
                                  key_dim=256,
                                  value_dim=512,
                                  use_bias=True),
             (target_cx, target_shape))
         self.assertEqual(
-            Attention_complexity(input_shape=[1, 100, 128],
+            attention_complexity(input_shape=[1, 100, 128],
                                  num_heads=4,
                                  key_dim=256,
                                  value_dim=512,

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -102,9 +102,8 @@ class ComplexityTest(tf.test.TestCase):
                            prev_cx=self.prev_cx),
             (dict_add(target_cx, self.prev_cx), target_shape))
         
-        
     def test_attention(self):
-        target_cx = {'flops': 109465600, 'params': 790656}
+        target_cx = {'flops': 109785600, 'params': 790656}
         target_shape = [1, 100, 128]
         self.assertEqual(
             attention_complexity(input_shape=[1, 100, 128],

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -89,31 +89,31 @@ class ComplexityTest(tf.test.TestCase):
         target_cx = {'flops': 978000, 'params': 9360}
         target_shape = [32, 100, 30]
         self.assertEqual(
-            GRU_complexity(input_shape=[32, 100, 20],
+            gru_complexity(input_shape=[32, 100, 20],
                            units=30,
                            use_bias=True,
                            bi=True),
             (target_cx, target_shape))
         self.assertEqual(
-            GRU_complexity(input_shape=[32, 100, 20],
+            gru_complexity(input_shape=[32, 100, 20],
                            units=30,
                            use_bias=True,
                            bi=True,
                            prev_cx=self.prev_cx),
             (dict_add(target_cx, self.prev_cx), target_shape))
         
-    def test_attention(self):
+    def test_multi_head_attention(self):
         target_cx = {'flops': 109785600, 'params': 790656}
-        target_shape = [1, 100, 128]
+        target_shape = [100, 128]
         self.assertEqual(
-            attention_complexity(input_shape=[1, 100, 128],
+            multi_head_attention_complexity(input_shape=[100, 128],
                                  num_heads=4,
                                  key_dim=256,
                                  value_dim=512,
                                  use_bias=True),
             (target_cx, target_shape))
         self.assertEqual(
-            attention_complexity(input_shape=[1, 100, 128],
+            multi_head_attention_complexity(input_shape=[100, 128],
                                  num_heads=4,
                                  key_dim=256,
                                  value_dim=512,

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -85,6 +85,45 @@ class ComplexityTest(tf.test.TestCase):
                               prev_cx=self.prev_cx),
             (dict_add(target_cx, self.prev_cx), target_shape))
 
+    def test_GRU_complexity(self):
+        target_cx = {'flops': 2676000, 'params': 9360}
+        target_shape = [32, 100, 30]
+        self.assertEqual(
+            GRU_complexity(input_shape=[32, 100, 20],
+                           units=30,
+                           layers=2,
+                           use_bias=True,
+                           bi=True),
+            (target_cx, target_shape))
+        self.assertEqual(
+            GRU_complexity(input_shape=[32, 100, 20],
+                           units=30,
+                           layers=2,
+                           use_bias=True,
+                           bi=True,
+                           prev_cx=self.prev_cx),
+            (dict_add(target_cx, self.prev_cx), target_shape))
+        
+        
+    def test_attention(self):
+        target_cx = {'flops': 125542400, 'params': 1052672}
+        target_shape = [1, 100, 256]
+        self.assertEqual(
+            Attention_complexity(input_shape=[1, 100, 256],
+                                 num_heads=4,
+                                 key_dim=256,
+                                 value_dim=256,
+                                 use_bias=True),
+            (target_cx, target_shape))
+        self.assertEqual(
+            Attention_complexity(input_shape=[1, 100, 256],
+                                 num_heads=4,
+                                 key_dim=256,
+                                 value_dim=256,
+                                 use_bias=True,
+                                 prev_cx=self.prev_cx),
+            (dict_add(target_cx, self.prev_cx), target_shape))
+    
     def test_safe_tuple(self):
         self.assertEqual((1, 1), safe_tuple(1, 2))
         self.assertEqual((1, 3), safe_tuple((1, 3), 2))

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -106,20 +106,20 @@ class ComplexityTest(tf.test.TestCase):
         
         
     def test_attention(self):
-        target_cx = {'flops': 125542400, 'params': 1052672}
-        target_shape = [1, 100, 256]
+        target_cx = {'flops': 109465600, 'params': 790656}
+        target_shape = [1, 100, 128]
         self.assertEqual(
-            Attention_complexity(input_shape=[1, 100, 256],
+            Attention_complexity(input_shape=[1, 100, 128],
                                  num_heads=4,
                                  key_dim=256,
-                                 value_dim=256,
+                                 value_dim=512,
                                  use_bias=True),
             (target_cx, target_shape))
         self.assertEqual(
-            Attention_complexity(input_shape=[1, 100, 256],
+            Attention_complexity(input_shape=[1, 100, 128],
                                  num_heads=4,
                                  key_dim=256,
-                                 value_dim=256,
+                                 value_dim=512,
                                  use_bias=True,
                                  prev_cx=self.prev_cx),
             (dict_add(target_cx, self.prev_cx), target_shape))


### PR DESCRIPTION
GRU와 attention의 complexity 추가입니다. parameter의 경우 일단 뇌피셜로 한 다음, 실제 레이어 파라미터를 빼서 맞는 것을 확인하였습니다. 

attention flops는 그냥 계산 순서대로 적었는데 parameter를 수정할때 쓴 bias부분에 맞추려면 flops도 약간의 수정이 필요한 상태입니다. (크게 차이가 나는 부분은 아니라, 일단 뒀고 그 부분은 추후 수정하겠습니다)

GRU의  Flops의 경우  #https://github.com/Lyken17/pytorch-OpCounter/blob/master/thop/rnn_hooks.py 이 부분을 참고하였습니다.
일단 matrix연산을 할때 linear와 비슷한 시간복잡도를 사용하는 것으로 보았을 때 적용해도 될 것 같았고, num_layer는 파이토치에는 있는데 텐서플로우에는 layer를 더 쌓는 방식이라 빼도 무방하지만 일단 1로 두고, 후에 필요에따라 수정해도 될 것 같아 두었습니다. 