### PR TITLE
모듈을 잘게 쪼개기

### DIFF
--- a/layers.py
+++ b/layers.py
@@ -9,20 +9,29 @@ You should not import class or functions from modules or models
 """
 
 
-def conv2d_block(filters,
+def conv2d_layer(filters,
                  kernel_size, 
                  strides=(1, 1), 
                  padding='same', 
-                 activation='relu', 
+                 groups=1,
                  use_bias=True, 
                  kernel_regularizer=None, 
-                 groups=1,
-                 norm_axis=-1,
-                 norm_eps=1e-3):
-    def _conv2d_block(inputs):
-        x = Conv2D(filters, kernel_size, strides=strides, padding=padding, use_bias=use_bias, kernel_regularizer=kernel_regularizer, groups=groups)(inputs)
-        x = BatchNormalization(norm_axis, epsilon=norm_eps)(x)
-        x = Activation(activation)(x) if activation else x
+                 activation=None, 
+                 bn_args=None):
+    if bn_args is None:
+        bn_args = {} # you can put axis, momentum, epsilon in bn_args
+
+    def _conv2d_layer(inputs):
+        x = Conv2D(filters, kernel_size, 
+                   strides=strides, 
+                   padding=padding, 
+                   groups=groups,
+                   use_bias=use_bias, 
+                   kernel_regularizer=kernel_regularizer)(inputs)
+        x = BatchNormalization(**bn_args)(x)
+        if activation:
+            x = Activation(activation)(x)
         return x
-    return _conv2d_block
+
+    return _conv2d_layer
 

--- a/layers.py
+++ b/layers.py
@@ -9,69 +9,20 @@ You should not import class or functions from modules or models
 """
 
 
-class Routing(Layer):
-    def __init__(self, out_channels, dropout_rate, temperature=30, **kwargs):
-        super(Routing, self).__init__(**kwargs)
-        self.avgpool = GlobalAveragePooling2D()
-        self.dropout = Dropout(rate=dropout_rate)
-        self.fc = Dense(units=out_channels)
-        self.softmax = Softmax()
-        self.temperature = temperature
+def conv2d_block(filters,
+                 kernel_size, 
+                 strides=(1, 1), 
+                 padding='same', 
+                 activation='relu', 
+                 use_bias=True, 
+                 kernel_regularizer=None, 
+                 groups=1,
+                 norm_axis=-1,
+                 norm_eps=1e-3):
+    def _conv2d_block(inputs):
+        x = Conv2D(filters, kernel_size, strides=strides, padding=padding, use_bias=use_bias, kernel_regularizer=kernel_regularizer, groups=groups)(inputs)
+        x = BatchNormalization(norm_axis, epsilon=norm_eps)(x)
+        x = Activation(activation)(x) if activation else x
+        return x
+    return _conv2d_block
 
-    def get_config(self):
-        config = super().get_config().copy()
-        config.update({
-            'fc': self.fc1
-        })
-        return config
-
-    def call(self, inputs, **kwargs):
-        """
-        :param inputs: (b, c, h, w)
-        :return: (b, out_features)
-        """
-        out = self.avgpool(inputs)
-        out = self.dropout(out)
-
-        # refer to paper: https://arxiv.org/pdf/1912.03458.pdf
-        out = self.softmax(self.fc(out) * 1.0 / self.temperature)
-        return out
-
-
-class CondConv2D(Layer):
-    def __init__(self, filters, kernel_size, stride=1, use_bias=True, num_experts=3, padding="same", **kwargs):
-        super(CondConv2D, self).__init__(**kwargs)
-
-        def conv2d(kernel_size, stride, filters, 
-                   kernel_regularizer=tf.keras.regularizers.l2(1e-3), 
-                   padding="same", use_bias=False,
-                   kernel_initializer="he_normal", **kwargs):
-            return Conv2D(kernel_size=kernel_size, strides=stride, 
-                          filters=filters, kernel_regularizer=kernel_regularizer, 
-                          padding=padding, use_bias=use_bias, 
-                          kernel_initializer=kernel_initializer, **kwargs)
-
-        self.routing = Routing(out_channels=num_experts, dropout_rate=0.2, name="routing_layer")
-        self.convs = []
-        for _ in range(num_experts):
-            self.convs.append(Conv2D(filters=filters, strides=stride, kernel_size=kernel_size, use_bias=use_bias, padding=padding))
-
-    def get_config(self):
-        config = super().get_config().copy()
-        config.update({
-            'convs': self.convs
-        })
-        return config
-
-    def call(self, inputs, **kwargs):
-        """
-        :param inputs: (b, h, w, c)
-        :return: (b, h_out, w_out, filters)
-        """
-        routing_weights = self.routing(inputs)
-        feature = routing_weights[:, 0] * tf.transpose(self.convs[0](inputs), perm=[1, 2, 3, 0])
-        for i in range(1, len(self.convs)):
-            feature += routing_weights[:, i] * tf.transpose(self.convs[i](inputs), perm=[1, 2, 3, 0])
-        feature = tf.transpose(feature, perm=[3, 0, 1, 2])
-        return feature
-    

--- a/layers.py
+++ b/layers.py
@@ -9,15 +9,15 @@ You should not import class or functions from modules or models
 """
 
 
-def conv2d_layer(filters,
-                 kernel_size, 
-                 strides=(1, 1), 
-                 padding='same', 
-                 groups=1,
-                 use_bias=True, 
-                 kernel_regularizer=None, 
-                 activation=None, 
-                 bn_args=None):
+def conv2d_bn(filters,
+              kernel_size, 
+              strides=(1, 1), 
+              padding='same', 
+              groups=1,
+              use_bias=True, 
+              kernel_regularizer=None, 
+              activation=None, 
+              bn_args=None):
     if bn_args is None:
         bn_args = {} # you can put axis, momentum, epsilon in bn_args
 

--- a/layers_test.py
+++ b/layers_test.py
@@ -5,14 +5,42 @@ from layers import *
 
 
 class LayersTest(tf.test.TestCase):
-    def test_Routing(self):
-        raise NotImplemented()
+    def test_conv2d_layer(self):
+        layer_args = dict(
+            filters=8,
+            kernel_size=3,
+            activation='relu',
+            bn_args={'momentum': 0.99, 'epsilon': 0.001},
+        )
 
-    def test_CondConv2D(self):
-        raise NotImplemented()
+        exp_input_shape = 32, 16, 16, 3 
+        exp_output_shape = 32, 16, 16, 8
 
-    def test_DConv2D(self):
-        raise NotImplemented()
+        self.layer_test(conv2d_layer, 
+                        layer_args, 
+                        exp_input_shape,
+                        exp_output_shape)
+
+    def layer_test(self, 
+                   layer_fn,
+                   layer_args: dict,
+                   exp_input_shape, 
+                   exp_output_shape):
+        '''
+        layer_fn: a func that will generate the layer
+        layer_args: args for layer_fn
+        exp_input_shape: expected input shape
+        exp_output_shape: expected output_shape
+
+        "batch size" must be included in both arguments
+        ex) [batch, time, chan]
+        '''
+        x = tf.zeros(exp_input_shape)
+        layer = layer_fn(**layer_args)
+
+        y = layer(x)
+
+        self.assertAllEqual(y.shape, exp_output_shape)
 
 
 if __name__ == '__main__':

--- a/layers_test.py
+++ b/layers_test.py
@@ -5,7 +5,7 @@ from layers import *
 
 
 class LayersTest(tf.test.TestCase):
-    def test_conv2d_layer(self):
+    def test_conv2d_bn(self):
         layer_args = dict(
             filters=8,
             kernel_size=3,
@@ -16,7 +16,7 @@ class LayersTest(tf.test.TestCase):
         exp_input_shape = 32, 16, 16, 3 
         exp_output_shape = 32, 16, 16, 8
 
-        self.layer_test(conv2d_layer, 
+        self.layer_test(conv2d_bn, 
                         layer_args, 
                         exp_input_shape,
                         exp_output_shape)

--- a/model_config/conv_temp.json
+++ b/model_config/conv_temp.json
@@ -4,7 +4,7 @@
     {
         "filters": 32,
         "depth": 3,
-	"strides": [1, 2]
+        "strides": [1, 2]
     },
     "SECOND": "bidirectional_GRU_block",
     "SECOND_ARGS":
@@ -17,38 +17,38 @@
     {
         "growth_rate": 16,
         "depth": 6,
-	"strides": [1, 2],
-	"bottleneck_ratio": 2,
-	"reduction_ratio": 0.5
+        "strides": [1, 2],
+        "bottleneck_ratio": 2,
+        "reduction_ratio": 0.5
     },
     "FOURTH": "res_basic_stage",
     "FOURTH_ARGS":
     {
         "filters": 256,
         "depth": 3,
-	"strides": [1, 2]
+        "strides": [1, 2]
     },
     "FIFTH": "another_conv_block",
     "FIFTH_ARGS":
     {
         "filters": 256,
         "depth": 2,
-	"pool_size": [1, 4]
+        "pool_size": [1, 4]
     },
     "SED": "simple_dense_block",
     "SED_ARGS":
     {
-	"units": [128],
-	"n_classes": 14,
-	"activation": "sigmoid",
-	"name": "sed_out"
+        "units": [128],
+        "n_classes": 14,
+        "activation": "sigmoid",
+        "name": "sed_out"
     },
     "DOA": "simple_dense_block",
     "DOA_ARGS":
     {
-	"units": [128],
-	"n_classes": 42,
-	"activation": "tanh",
-	"name": "doa_out"
+        "units": [128],
+        "n_classes": 42,
+        "activation": "tanh",
+        "name": "doa_out"
     }
 }

--- a/model_config/conv_temp.json
+++ b/model_config/conv_temp.json
@@ -1,0 +1,57 @@
+{
+    "filters": 32,
+    "FIRST": "res_bottleneck_stage",
+    "FIRST_ARGS":
+    {
+        "filters": 32,
+        "depth": 3,
+	"strides": [1, 2]
+    },
+    "SECOND": "dense_net_block",
+    "SECOND_ARGS":
+    {
+        "growth_rate": 16,
+        "depth": 4,
+	"strides": [1, 2],
+	"bottleneck_ratio": 2,
+	"reduction_ratio": 0.5
+    },
+    "THIRD": "dense_net_block",
+    "THIRD_ARGS":
+    {
+        "growth_rate": 16,
+        "depth": 6,
+	"strides": [1, 2],
+	"bottleneck_ratio": 2,
+	"reduction_ratio": 0.5
+    },
+    "FOURTH": "res_bottleneck_stage",
+    "FOURTH_ARGS":
+    {
+        "filters": 256,
+        "depth": 3,
+	"strides": [1, 2]
+    },
+    "FIFTH": "bidirectional_GRU_block",
+    "FIFTH_ARGS":
+    {
+        "units": [128, 128],
+        "dropout_rate": 0.0
+    },
+    "SED": "simple_dense_block",
+    "SED_ARGS":
+    {
+	"units": [128],
+	"n_classes": 14,
+	"activation": "sigmoid",
+	"name": "sed_out"
+    },
+    "DOA": "simple_dense_block",
+    "DOA_ARGS":
+    {
+	"units": [128],
+	"n_classes": 42,
+	"activation": "tanh",
+	"name": "doa_out"
+    }
+}

--- a/model_config/conv_temp.json
+++ b/model_config/conv_temp.json
@@ -1,19 +1,20 @@
 {
-    "FIRST": "res_bottleneck_stage",
-    "FIRST_ARGS":
+    "BLOCK0": "res_bottleneck_stage",
+    "BLOCK0_ARGS":
     {
         "filters": 32,
         "depth": 3,
         "strides": [1, 2]
     },
-    "SECOND": "bidirectional_GRU_block",
-    "SECOND_ARGS":
+    "BLOCK1": "another_conv_block",
+    "BLOCK1_ARGS":
     {
-        "units": [128, 128],
-        "dropout_rate": 0.0
+        "filters": 256,
+        "depth": 2,
+        "pool_size": [1, 4]
     },
-    "THIRD": "dense_net_block",
-    "THIRD_ARGS":
+    "BLOCK2": "dense_net_block",
+    "BLOCK2_ARGS":
     {
         "growth_rate": 16,
         "depth": 6,
@@ -21,19 +22,18 @@
         "bottleneck_ratio": 2,
         "reduction_ratio": 0.5
     },
-    "FOURTH": "res_basic_stage",
-    "FOURTH_ARGS":
+    "BLOCK3": "res_basic_stage",
+    "BLOCK3_ARGS":
     {
         "filters": 256,
         "depth": 3,
         "strides": [1, 2]
     },
-    "FIFTH": "another_conv_block",
-    "FIFTH_ARGS":
+    "BLOCK4": "bidirectional_GRU_block",
+    "BLOCK4_ARGS":
     {
-        "filters": 256,
-        "depth": 2,
-        "pool_size": [1, 4]
+        "units": [128, 128],
+        "dropout_rate": 0.0
     },
     "SED": "simple_dense_block",
     "SED_ARGS":

--- a/model_config/conv_temp.json
+++ b/model_config/conv_temp.json
@@ -1,5 +1,4 @@
 {
-    "filters": 32,
     "FIRST": "res_bottleneck_stage",
     "FIRST_ARGS":
     {
@@ -7,14 +6,11 @@
         "depth": 3,
 	"strides": [1, 2]
     },
-    "SECOND": "dense_net_block",
+    "SECOND": "bidirectional_GRU_block",
     "SECOND_ARGS":
     {
-        "growth_rate": 16,
-        "depth": 4,
-	"strides": [1, 2],
-	"bottleneck_ratio": 2,
-	"reduction_ratio": 0.5
+        "units": [128, 128],
+        "dropout_rate": 0.0
     },
     "THIRD": "dense_net_block",
     "THIRD_ARGS":
@@ -25,18 +21,19 @@
 	"bottleneck_ratio": 2,
 	"reduction_ratio": 0.5
     },
-    "FOURTH": "res_bottleneck_stage",
+    "FOURTH": "res_basic_stage",
     "FOURTH_ARGS":
     {
         "filters": 256,
         "depth": 3,
 	"strides": [1, 2]
     },
-    "FIFTH": "bidirectional_GRU_block",
+    "FIFTH": "another_conv_block",
     "FIFTH_ARGS":
     {
-        "units": [128, 128],
-        "dropout_rate": 0.0
+        "filters": 256,
+        "depth": 2,
+	"pool_size": [1, 4]
     },
     "SED": "simple_dense_block",
     "SED_ARGS":

--- a/model_config/resnet_gru.json
+++ b/model_config/resnet_gru.json
@@ -5,28 +5,28 @@
     {
         "filters": 32,
         "depth": 3,
-	"strides": [1, 2]
+        "strides": [1, 2]
     },
     "SECOND": "res_bottleneck_stage",
     "SECOND_ARGS":
     {
         "filters": 64,
         "depth": 4,
-	"strides": [1, 2]
+        "strides": [1, 2]
     },
     "THIRD": "res_bottleneck_stage",
     "THIRD_ARGS":
     {
         "filters": 128,
         "depth": 6,
-	"strides": [1, 2]
+        "strides": [1, 2]
     },
     "FOURTH": "res_bottleneck_stage",
     "FOURTH_ARGS":
     {
         "filters": 256,
         "depth": 3,
-	"strides": [1, 2]
+        "strides": [1, 2]
     },
     "FIFTH": "bidirectional_GRU_block",
     "FIFTH_ARGS":
@@ -37,17 +37,17 @@
     "SED": "simple_dense_block",
     "SED_ARGS":
     {
-	"units": [128],
-	"n_classes": 14,
-	"activation": "sigmoid",
-	"name": "sed_out"
+        "units": [128],
+        "n_classes": 14,
+        "activation": "sigmoid",
+        "name": "sed_out"
     },
     "DOA": "simple_dense_block",
     "DOA_ARGS":
     {
-	"units": [128],
-	"n_classes": 42,
-	"activation": "tanh",
-	"name": "doa_out"
+        "units": [128],
+        "n_classes": 42,
+        "activation": "tanh",
+        "name": "doa_out"
     }
 }

--- a/model_config/resnet_gru.json
+++ b/model_config/resnet_gru.json
@@ -1,35 +1,35 @@
 {
     "filters": 32,
-    "FIRST": "res_bottleneck_stage",
-    "FIRST_ARGS":
+    "BLOCK0": "res_bottleneck_stage",
+    "BLOCK0_ARGS":
     {
         "filters": 32,
         "depth": 3,
         "strides": [1, 2]
     },
-    "SECOND": "res_bottleneck_stage",
-    "SECOND_ARGS":
+    "BLOCK1": "res_bottleneck_stage",
+    "BLOCK1_ARGS":
     {
         "filters": 64,
         "depth": 4,
         "strides": [1, 2]
     },
-    "THIRD": "res_bottleneck_stage",
-    "THIRD_ARGS":
+    "BLOCK2": "res_bottleneck_stage",
+    "BLOCK2_ARGS":
     {
         "filters": 128,
         "depth": 6,
         "strides": [1, 2]
     },
-    "FOURTH": "res_bottleneck_stage",
-    "FOURTH_ARGS":
+    "BLOCK3": "res_bottleneck_stage",
+    "BLOCK3_ARGS":
     {
         "filters": 256,
         "depth": 3,
         "strides": [1, 2]
     },
-    "FIFTH": "bidirectional_GRU_block",
-    "FIFTH_ARGS":
+    "BLOCK4": "bidirectional_GRU_block",
+    "BLOCK4_ARGS":
     {
         "units": [128, 128],
         "dropout_rate": 0.0

--- a/model_config/resnet_gru.json
+++ b/model_config/resnet_gru.json
@@ -1,0 +1,53 @@
+{
+    "filters": 32,
+    "FIRST": "res_bottleneck_stage",
+    "FIRST_ARGS":
+    {
+        "filters": 32,
+        "depth": 3,
+	"strides": [1, 2]
+    },
+    "SECOND": "res_bottleneck_stage",
+    "SECOND_ARGS":
+    {
+        "filters": 64,
+        "depth": 4,
+	"strides": [1, 2]
+    },
+    "THIRD": "res_bottleneck_stage",
+    "THIRD_ARGS":
+    {
+        "filters": 128,
+        "depth": 6,
+	"strides": [1, 2]
+    },
+    "FOURTH": "res_bottleneck_stage",
+    "FOURTH_ARGS":
+    {
+        "filters": 256,
+        "depth": 3,
+	"strides": [1, 2]
+    },
+    "FIFTH": "bidirectional_GRU_block",
+    "FIFTH_ARGS":
+    {
+        "units": [128, 128],
+        "dropout_rate": 0.0
+    },
+    "SED": "simple_dense_block",
+    "SED_ARGS":
+    {
+	"units": [128],
+	"n_classes": 14,
+	"activation": "sigmoid",
+	"name": "sed_out"
+    },
+    "DOA": "simple_dense_block",
+    "DOA_ARGS":
+    {
+	"units": [128],
+	"n_classes": 42,
+	"activation": "tanh",
+	"name": "doa_out"
+    }
+}

--- a/models.py
+++ b/models.py
@@ -43,7 +43,7 @@ def seldnet_v1(input_shape, model_config):
 def conv_temporal(input_shape, model_config):
     inputs = Input(shape=input_shape[-3:])
     
-    x = layers.conv2d_layer(16, 7, strides=1, activation='relu')(inputs)
+    x = layers.conv2d_bn(16, 7, strides=1, activation='relu')(inputs)
     x = MaxPooling2D(5, strides=(5, 2), padding='same')(x)
 
     x = getattr(modules, model_config.FIRST)(model_config.FIRST_ARGS)(x)

--- a/models.py
+++ b/models.py
@@ -44,11 +44,13 @@ def conv_temporal(input_shape, model_config):
     inputs = Input(shape=input_shape[-3:])
     
     x = layers.conv2d_layer(16, 7, strides=1, activation='relu')(inputs)
+    x = MaxPooling2D(5, strides=(5, 2), padding='same')(x)
 
     x = getattr(modules, model_config.FIRST)(model_config.FIRST_ARGS)(x)
     x = getattr(modules, model_config.SECOND)(model_config.SECOND_ARGS)(x)
     x = getattr(modules, model_config.THIRD)(model_config.THIRD_ARGS)(x)
     x = getattr(modules, model_config.FOURTH)(model_config.FOURTH_ARGS)(x)
+    x = getattr(modules, model_config.FIFTH)(model_config.FIFTH_ARGS)(x)
 
     sed = getattr(modules, model_config.SED)(model_config.SED_ARGS)(x)
     doa = getattr(modules, model_config.DOA)(model_config.DOA_ARGS)(x)

--- a/models.py
+++ b/models.py
@@ -3,6 +3,8 @@ from tensorflow.keras.activations import *
 from tensorflow.keras.layers import *
 
 import modules
+import layers
+
 
 """
 Models
@@ -37,3 +39,19 @@ def seldnet_v1(input_shape, model_config):
 
     return tf.keras.Model(inputs=inputs, outputs=[sed, doa])
     
+
+def conv_temporal(input_shape, model_config):
+    inputs = Input(shape=input_shape[-3:])
+    
+    x = layers.conv2d_layer(16, 7, strides=1, activation='relu')(inputs)
+
+    x = getattr(modules, model_config.FIRST)(model_config.FIRST_ARGS)(x)
+    x = getattr(modules, model_config.SECOND)(model_config.SECOND_ARGS)(x)
+    x = getattr(modules, model_config.THIRD)(model_config.THIRD_ARGS)(x)
+    x = getattr(modules, model_config.FOURTH)(model_config.FOURTH_ARGS)(x)
+
+    sed = getattr(modules, model_config.SED)(model_config.SED_ARGS)(x)
+    doa = getattr(modules, model_config.DOA)(model_config.DOA_ARGS)(x)
+
+    return tf.keras.Model(inputs=inputs, outputs=[sed, doa])
+

--- a/models.py
+++ b/models.py
@@ -20,6 +20,8 @@ def seldnet(input_shape, model_config):
 
     x = getattr(modules, model_config.FIRST)(model_config.FIRST_ARGS)(inputs)
     x = getattr(modules, model_config.SECOND)(model_config.SECOND_ARGS)(x)
+    x = Reshape((-1, x.shape[-2]*x.shape[-1]))(x)
+
     sed = getattr(modules, model_config.SED)(model_config.SED_ARGS)(x)
     doa = getattr(modules, model_config.DOA)(model_config.DOA_ARGS)(x)
 
@@ -31,6 +33,8 @@ def seldnet_v1(input_shape, model_config):
 
     x = getattr(modules, model_config.FIRST)(model_config.FIRST_ARGS)(inputs)
     x = getattr(modules, model_config.SECOND)(model_config.SECOND_ARGS)(x)
+    x = Reshape((-1, x.shape[-2]*x.shape[-1]))(x)
+
     sed = getattr(modules, model_config.SED)(model_config.SED_ARGS)(x)
     doa = getattr(modules, model_config.DOA)(model_config.DOA_ARGS)(x)
 
@@ -42,15 +46,21 @@ def seldnet_v1(input_shape, model_config):
 
 def conv_temporal(input_shape, model_config):
     inputs = Input(shape=input_shape[-3:])
+
+    filters = 24
+    pool_size = [5, 2]
     
-    x = layers.conv2d_bn(16, 7, strides=1, activation='relu')(inputs)
-    x = MaxPooling2D(5, strides=(5, 2), padding='same')(x)
+    x = layers.conv2d_bn(filters, 7, padding='same', activation='relu')(inputs)
+    if pool_size[0] > 1 or pool_size[1] > 1:
+        x = MaxPooling2D(pool_size, padding='same')(x)
 
     x = getattr(modules, model_config.FIRST)(model_config.FIRST_ARGS)(x)
     x = getattr(modules, model_config.SECOND)(model_config.SECOND_ARGS)(x)
     x = getattr(modules, model_config.THIRD)(model_config.THIRD_ARGS)(x)
     x = getattr(modules, model_config.FOURTH)(model_config.FOURTH_ARGS)(x)
     x = getattr(modules, model_config.FIFTH)(model_config.FIFTH_ARGS)(x)
+
+    x = Reshape((-1, x.shape[-2]*x.shape[-1]))(x)
 
     sed = getattr(modules, model_config.SED)(model_config.SED_ARGS)(x)
     doa = getattr(modules, model_config.DOA)(model_config.DOA_ARGS)(x)

--- a/models_test.py
+++ b/models_test.py
@@ -10,7 +10,7 @@ class ModelsTest(tf.test.TestCase):
     def test_seldnet_v1(self):
         raise NotImplemented()
 
-    def test_seldnet_v1(self):
+    def test_conv_temporal(self):
         raise NotImplemented()
 
 

--- a/modules.py
+++ b/modules.py
@@ -29,8 +29,8 @@ def simple_conv_block(model_config: dict):
     def conv_block(inputs):
         x = inputs
         for i in range(len(filters)):
-            x = conv2d_block(filters[i], kernel_size=3, 
-                             kernel_regularizer=kernel_regularizer)(x)
+            x = conv2d_bn(filters[i], kernel_size=3, 
+                          kernel_regularizer=kernel_regularizer)(x)
             x = MaxPooling2D(pool_size=pool_size[i])(x)
             x = Dropout(dropout_rate)(x)
         return x

--- a/modules.py
+++ b/modules.py
@@ -86,6 +86,150 @@ def res_bottleneck_block(model_config: dict):
      return bottleneck_block
 
 
+def dense_net_block(model_config: dict):
+    filters = model_config['filters']
+    block_num = model_config['block_num']
+
+    kernel_regularizer = tf.keras.regularizers.l1_l2(
+        **model_config.get('kernel_regularizer', {'l1': 0., 'l2': 0.}))
+
+    def conv_block(x, growth_rate):
+        x1 = BatchNormalization(epsilon=1.001e-5)(x)
+        x1 = Activation('relu')(x1)
+        x1 = conv2d_block(4 * growth_rate, 1, use_bias=False, kernel_regularizer=kernel_regularizer, norm_eps=1.001e-5)(x1)
+        x1 = Conv2D(growth_rate, 3, padding='same', use_bias=False, kernel_regularizer=kernel_regularizer)(x1)
+        x = Concatenate()([x, x1])
+        return x
+
+    def transition_block(x, reduction):
+        x = BatchNormalization(epsilon=1.001e-5)(x)
+        x = Activation('relu')(x)
+        x = Conv2D(x.shape[-1] * reduction, 1, use_bias=False, kernel_regularizer=kernel_regularizer)(x)
+        x = AveragePooling2D(2, strides=(1,2), padding='same')(x)
+        return x
+    
+    def dense_blocks(x, block_num):
+        for i in range(block_num):
+            x = conv_block(x, 32)
+        return x
+
+    def _dense_block(inputs):
+        x = conv2d_block(filters, 7, strides=(1,2), use_bias=False, kernel_regularizer=kernel_regularizer, norm_eps=1.001e-5)(inputs)
+        x = MaxPooling2D(pool_size=(5,2))(x)
+
+        for i in range(len(block_num)):
+            x = dense_blocks(x, block_num[i])
+            x = transition_block(x, 0.5) if i != len(block_num) - 1 else x
+
+        x = BatchNormalization(epsilon=1.001e-5)(x)
+        x = Activation('relu')(x)
+
+        x = Reshape((-1, x.shape[-2] * x.shape[-1]))(x)
+        return x
+    return _dense_block
+
+
+def xception_block(model_config: dict):
+    filters = model_config['filters']
+    block_num = model_config['block_num']
+    
+    kernel_regularizer = tf.keras.regularizers.l1_l2(
+        **model_config.get('kernel_regularizer', {'l1': 0., 'l2': 0.}))
+
+    def _sepconv_block(inputs, filters, activation):
+        x = SeparableConv2D(filters, 3, padding='same', use_bias=False, kernel_regularizer=kernel_regularizer)(inputs)
+        x = BatchNormalization()(x)
+        x = Activation(activation)(x) if activation else x
+        return x
+    
+    def _residual_block(inputs, filters):
+        if type(filters) != list:
+            filters1 = filters2 = filters
+        else:
+            filters1, filters2 = filters
+
+        residual = conv2d_block(filters2, 1, strides=(1,2), padding='same', use_bias=False, kernel_regularizer=kernel_regularizer, activation=None)(inputs)
+
+        x = _sepconv_block(inputs, filters1, 'relu')
+        x = _sepconv_block(x, filters2, None)
+        x = MaxPooling2D((3,3), strides=(1,2), padding='same')(x)
+
+        x = add([x, residual])
+        return x
+
+    def _xception_net_block(inputs):
+        x = conv2d_block(filters, 3, use_bias=False, kernel_regularizer=kernel_regularizer)(inputs)
+        x = MaxPooling2D(pool_size=(5,1))(x)
+        x = conv2d_block(filters * 2, 3, use_bias=False, kernel_regularizer=kernel_regularizer)(x)
+
+        x = _residual_block(x, filters * 4)
+        x = _residual_block(x, filters * 8)
+        x = _residual_block(x, int(filters * 22.75))
+
+        for i in range(block_num):
+            residual = x
+
+            x = Activation('relu')(x)
+            x = _sepconv_block(x, int(filters * 22.75), 'relu')
+            x = _sepconv_block(x, int(filters * 22.75), 'relu')
+            x = _sepconv_block(x, int(filters * 22.75), None)
+
+            x = add([x, residual])
+
+        x = _residual_block(x, [int(filters * 22.75), filters * 32])
+
+        x = _sepconv_block(x, filters * 48, 'relu')
+        x = _sepconv_block(x, filters * 64, 'relu')
+        x = Reshape((-1, x.shape[-2]*x.shape[-1]))(x)
+        return x
+    return _xception_net_block
+    
+
+def resnet50_block(model_config: dict):
+    filters = model_config['filters']
+    block_num = model_config['block_num']
+
+    kernel_regularizer = tf.keras.regularizers.l1_l2(
+        **model_config.get('kernel_regularizer', {'l1': 0., 'l2': 0.}))
+
+    def block1(x, filters, kernel_size=3, strides=1, conv_shortcut=True):
+        if conv_shortcut:
+            shortcut = conv2d_block(4 * filters, 1, strides=(1, strides), kernel_regularizer=kernel_regularizer, activation=None)(x)
+        else:
+            shortcut = x
+
+        x = conv2d_block(filters, 1, strides=(1, strides), kernel_regularizer=kernel_regularizer, norm_eps=1.001e-5)(x)
+
+        x = conv2d_block(filters, kernel_size, kernel_regularizer=kernel_regularizer, norm_eps=1.001e-5)(x)
+
+        x = conv2d_block(4 * filters, 1, kernel_regularizer=kernel_regularizer, activation=None, norm_eps=1.001e-5)(x)
+
+        x = Add()([shortcut, x])
+        x = Activation('relu')(x)
+        return x
+
+    def stack(x, filters, blocks, strides=2):
+        x = block1(x, filters, strides=strides)
+        for _ in range(blocks - 1):
+            x = block1(x, filters, conv_shortcut=False)
+        return x
+
+    def stack_fn(x):
+        x = stack(x, filters, block_num[0], strides=1)
+        x = stack(x, filters * 2, block_num[1])
+        x = stack(x, filters * 4, block_num[2])
+        return stack(x, filters * 8, block_num[3])
+
+    def _resnet50_block(inputs):
+        x = conv2d_block(filters, 7, strides=(1, 2), kernel_regularizer=kernel_regularizer, norm_eps=1.001e-5)(inputs)
+
+        x = MaxPooling2D(3, strides=(5, 2), padding='same')(x)
+        x = stack_fn(x)
+        x = Reshape((-1, x.shape[-2] * x.shape[-1]))(x)
+        return x
+    return _resnet50_block
+
+
 """      sequential blocks      """
 def bidirectional_GRU_block(model_config: dict):
     # mandatory parameters
@@ -162,150 +306,6 @@ def simple_dense_block(model_config: dict):
         return x
 
     return dense_block
-
-
-def xception_block(model_config: dict):
-    filters = model_config['filters']
-    block_num = model_config['block_num']
-    
-    kernel_regularizer = tf.keras.regularizers.l1_l2(
-        **model_config.get('kernel_regularizer', {'l1': 0., 'l2': 0.}))
-
-    def _sepconv_block(inputs, filters, activation):
-        x = SeparableConv2D(filters, 3, padding='same', use_bias=False, kernel_regularizer=kernel_regularizer)(inputs)
-        x = BatchNormalization()(x)
-        x = Activation(activation)(x) if activation else x
-        return x
-    
-    def _residual_block(inputs, filters):
-        if type(filters) != list:
-            filters1 = filters2 = filters
-        else:
-            filters1, filters2 = filters
-
-        residual = conv2d_block(filters2, 1, strides=(1,2), padding='same', use_bias=False, kernel_regularizer=kernel_regularizer, activation=None)(inputs)
-
-        x = _sepconv_block(inputs, filters1, 'relu')
-        x = _sepconv_block(x, filters2, None)
-        x = MaxPooling2D((3,3), strides=(1,2), padding='same')(x)
-
-        x = add([x, residual])
-        return x
-
-    def _xception_net_block(inputs):
-        x = conv2d_block(filters, 3, use_bias=False, kernel_regularizer=kernel_regularizer)(inputs)
-        x = MaxPooling2D(pool_size=(5,1))(x)
-        x = conv2d_block(filters * 2, 3, use_bias=False, kernel_regularizer=kernel_regularizer)(x)
-
-        x = _residual_block(x, filters * 4)
-        x = _residual_block(x, filters * 8)
-        x = _residual_block(x, int(filters * 22.75))
-
-        for i in range(block_num):
-            residual = x
-
-            x = Activation('relu')(x)
-            x = _sepconv_block(x, int(filters * 22.75), 'relu')
-            x = _sepconv_block(x, int(filters * 22.75), 'relu')
-            x = _sepconv_block(x, int(filters * 22.75), None)
-
-            x = add([x, residual])
-
-        x = _residual_block(x, [int(filters * 22.75), filters * 32])
-
-        x = _sepconv_block(x, filters * 48, 'relu')
-        x = _sepconv_block(x, filters * 64, 'relu')
-        x = Reshape((-1, x.shape[-2]*x.shape[-1]))(x)
-        return x
-    return _xception_net_block
-    
-
-def dense_net_block(model_config: dict):
-    filters = model_config['filters']
-    block_num = model_config['block_num']
-
-    kernel_regularizer = tf.keras.regularizers.l1_l2(
-        **model_config.get('kernel_regularizer', {'l1': 0., 'l2': 0.}))
-
-    def conv_block(x, growth_rate):
-        x1 = BatchNormalization(epsilon=1.001e-5)(x)
-        x1 = Activation('relu')(x1)
-        x1 = conv2d_block(4 * growth_rate, 1, use_bias=False, kernel_regularizer=kernel_regularizer, norm_eps=1.001e-5)(x1)
-        x1 = Conv2D(growth_rate, 3, padding='same', use_bias=False, kernel_regularizer=kernel_regularizer)(x1)
-        x = Concatenate()([x, x1])
-        return x
-
-    def transition_block(x, reduction):
-        x = BatchNormalization(epsilon=1.001e-5)(x)
-        x = Activation('relu')(x)
-        x = Conv2D(x.shape[-1] * reduction, 1, use_bias=False, kernel_regularizer=kernel_regularizer)(x)
-        x = AveragePooling2D(2, strides=(1,2), padding='same')(x)
-        return x
-    
-    def dense_blocks(x, block_num):
-        for i in range(block_num):
-            x = conv_block(x, 32)
-        return x
-
-    def _dense_block(inputs):
-        x = conv2d_block(filters, 7, strides=(1,2), use_bias=False, kernel_regularizer=kernel_regularizer, norm_eps=1.001e-5)(inputs)
-        x = MaxPooling2D(pool_size=(5,2))(x)
-
-        for i in range(len(block_num)):
-            x = dense_blocks(x, block_num[i])
-            x = transition_block(x, 0.5) if i != len(block_num) - 1 else x
-
-        x = BatchNormalization(epsilon=1.001e-5)(x)
-        x = Activation('relu')(x)
-
-        x = Reshape((-1, x.shape[-2] * x.shape[-1]))(x)
-        return x
-    return _dense_block
-    
-
-def resnet50_block(model_config: dict):
-    filters = model_config['filters']
-    block_num = model_config['block_num']
-
-    kernel_regularizer = tf.keras.regularizers.l1_l2(
-        **model_config.get('kernel_regularizer', {'l1': 0., 'l2': 0.}))
-
-    def block1(x, filters, kernel_size=3, strides=1, conv_shortcut=True):
-        if conv_shortcut:
-            shortcut = conv2d_block(4 * filters, 1, strides=(1, strides), kernel_regularizer=kernel_regularizer, activation=None)(x)
-        else:
-            shortcut = x
-
-        x = conv2d_block(filters, 1, strides=(1, strides), kernel_regularizer=kernel_regularizer, norm_eps=1.001e-5)(x)
-
-        x = conv2d_block(filters, kernel_size, kernel_regularizer=kernel_regularizer, norm_eps=1.001e-5)(x)
-
-        x = conv2d_block(4 * filters, 1, kernel_regularizer=kernel_regularizer, activation=None, norm_eps=1.001e-5)(x)
-
-        x = Add()([shortcut, x])
-        x = Activation('relu')(x)
-        return x
-
-    def stack(x, filters, blocks, strides=2):
-        x = block1(x, filters, strides=strides)
-        for _ in range(blocks - 1):
-            x = block1(x, filters, conv_shortcut=False)
-        return x
-
-    def stack_fn(x):
-        x = stack(x, filters, block_num[0], strides=1)
-        x = stack(x, filters * 2, block_num[1])
-        x = stack(x, filters * 4, block_num[2])
-        return stack(x, filters * 8, block_num[3])
-
-    def _resnet50_block(inputs):
-        x = conv2d_block(filters, 7, strides=(1, 2), kernel_regularizer=kernel_regularizer, norm_eps=1.001e-5)(inputs)
-
-        x = MaxPooling2D(3, strides=(5, 2), padding='same')(x)
-        x = stack_fn(x)
-        x = Reshape((-1, x.shape[-2] * x.shape[-1]))(x)
-        return x
-    return _resnet50_block
     
 
 def conv2d_block(filters,

--- a/modules.py
+++ b/modules.py
@@ -37,6 +37,40 @@ def simple_conv_block(model_config: dict):
     return conv_block
 
 
+def another_conv_block(model_config: dict):
+    # mandatory parameters
+    filters = model_config['filters']
+    depth = model_config['depth']
+    pool_size = model_config['pool_size']
+
+    activation = model_config.get('activation', 'relu')
+
+    if isinstance(pool_size, int):
+        pool_size = (pool_size, pool_size)
+
+    def conv_block(inputs):
+        x = inputs
+
+        for i in range(depth):
+            out = BatchNormalization()(x)
+            out = Activation(activation)(out)
+            out = Conv2D(filters, 3, padding='same')(out)
+
+            out = BatchNormalization()(x)
+            out = Activation(activation)(out)
+            out = Conv2D(filters, 3, padding='same')(out)
+
+            if x.shape[-1] != filters:
+                x = Conv2D(filters, 1)(x)
+            x = x + out
+
+        if pool_size[0] > 1 or pool_size[1] > 1:
+            x = MaxPool2D(pool_size, strides=pool_size)(x)
+
+        return x
+    return conv_block
+
+
 def res_basic_stage(model_config: dict):
     # mandatory parameters
     depth = model_config['depth']

--- a/modules.py
+++ b/modules.py
@@ -11,6 +11,7 @@ Use only custom layers or predefined
 """
 
 """      conv based blocks      """
+
 def simple_conv_block(model_config: dict):
     # mandatory parameters
     filters = model_config['filters']
@@ -47,7 +48,7 @@ def res_bottleneck_stage(model_config: dict):
             x = res_bottleneck_block(model_config)(x)
             model_config['strides'] = 1
         return x
-     return stage
+    return stage
 
 
 def res_bottleneck_block(model_config: dict):
@@ -307,21 +308,3 @@ def simple_dense_block(model_config: dict):
 
     return dense_block
     
-
-def conv2d_block(filters,
-                 kernel_size, 
-                 strides=(1, 1), 
-                 padding='same', 
-                 activation='relu', 
-                 use_bias=True, 
-                 kernel_regularizer=None, 
-                 groups=1,
-                 norm_axis=-1,
-                 norm_eps=1e-3):
-    def _conv2d_block(inputs):
-        x = Conv2D(filters, kernel_size, strides=strides, padding=padding, use_bias=use_bias, kernel_regularizer=kernel_regularizer, groups=groups)(inputs)
-        x = BatchNormalization(norm_axis, epsilon=norm_eps)(x)
-        x = Activation(activation)(x) if activation else x
-        return x
-    return _conv2d_block
-

--- a/modules.py
+++ b/modules.py
@@ -42,6 +42,7 @@ def res_bottleneck_stage(model_config: dict):
     depth = model_config['depth']
     strides = model_config['strides']
     model_config = copy.deepcopy(model_config)
+
     def stage(inputs):
         x = inputs
         for i in range(depth):
@@ -55,9 +56,9 @@ def res_bottleneck_block(model_config: dict):
      # mandatory parameters
      filters = model_config['filters']
      strides = model_config['strides']
-     groups = model_config['groups']
-     bottleneck_ratio = model_config['bottleneck_ratio']
 
+     groups = model_config.get('groups', 1)
+     bottleneck_ratio = model_config.get('bottleneck_ratio', 1)
      activation = model_config.get('activation', 'relu')
 
      if isinstance(strides, int):

--- a/modules.py
+++ b/modules.py
@@ -11,7 +11,6 @@ Use only custom layers or predefined
 """
 
 """      conv based blocks      """
-
 def simple_conv_block(model_config: dict):
     # mandatory parameters
     filters = model_config['filters']

--- a/modules.py
+++ b/modules.py
@@ -98,7 +98,7 @@ def res_basic_block(model_config: dict):
     if isinstance(strides, int):
         strides = (strides, strides)
 
-    def bottleneck_block(inputs):
+    def basic_block(inputs):
         out = Conv2D(filters, 3, strides, padding='same', groups=groups)(inputs)
         out = BatchNormalization()(out)
         out = Activation(activation)(out)
@@ -114,7 +114,7 @@ def res_basic_block(model_config: dict):
 
         return out
 
-    return bottleneck_block
+    return basic_block
 
 
 def res_bottleneck_stage(model_config: dict):

--- a/modules.py
+++ b/modules.py
@@ -273,8 +273,9 @@ def bidirectional_GRU_block(model_config: dict):
 
     def GRU_block(inputs):
         x = inputs
-        if len(x.shape) == 4: # [batch, time, freq, chan]
-            x = Reshape((-1, x.shape[-2]*x.shape[-1]))(x)
+        x_shape = x.shape
+        if len(x_shape) == 4: # [batch, time, freq, chan]
+            x = Reshape((-1, x_shape[-2]*x_shape[-1]))(x)
 
         for units in units_per_layer:
             x = Bidirectional(
@@ -282,6 +283,10 @@ def bidirectional_GRU_block(model_config: dict):
                     dropout=dropout_rate, recurrent_dropout=dropout_rate, 
                     return_sequences=True),
                 merge_mode='mul')(x)
+
+        if len(x_shape) == 4:
+            x = Reshape((*x_shape[-3:-1], -1))(x)
+
         return x
 
     return GRU_block

--- a/modules.py
+++ b/modules.py
@@ -177,22 +177,21 @@ def dense_net_block(model_config: dict):
 
     bottleneck_ratio = model_config.get('bottleneck_ratio', 4)
     reduction_ratio = model_config.get('reduction_ratio', 0.5)
-    bn_args = model_config.get('bn_args', {})
 
     def _dense_net_block(inputs):
         x = inputs
 
         for i in range(depth):
-            out = BatchNormalization(**bn_args)(x)
+            out = BatchNormalization()(x)
             out = Activation('relu')(out)
             out = Conv2D(bottleneck_ratio * growth_rate, 1, use_bias=False)(out)
-            out = BatchNormalization(**bn_args)(out)
+            out = BatchNormalization()(out)
             out = Activation('relu')(out)
             out = Conv2D(growth_rate, 3, padding='same', use_bias=True)(out)
             x = Concatenate(axis=-1)([x, out])
 
         if strides not in [1, (1, 1), [1, 1]]:
-            x = BatchNormalization(**bn_args)(x)
+            x = BatchNormalization()(x)
             x = Activation('relu')(x)
             x = Conv2D(int(x.shape[-1] * reduction_ratio), 1, use_bias=False)(x)
             x = AveragePooling2D(strides, strides)(x)

--- a/modules_test.py
+++ b/modules_test.py
@@ -54,54 +54,6 @@ class ModulesTest(tf.test.TestCase):
                          exp_input_shape,
                          exp_output_shape)
 
-    def test_bidirectional_GRU_block(self):
-        model_config = {
-            'units': [128, 128], # mandatory
-            'dropout_rate': 0.3,
-        }
-
-        exp_input_shape = 32, 10, 32, 8
-        exp_output_shape = 32, 10, 128
-
-        self.block_test(bidirectional_GRU_block, 
-                        model_config, 
-                        exp_input_shape,
-                        exp_output_shape)
-
-    def test_transformer_encoder_layer(self):
-        model_config = {
-            'd_model': 64, # mandatory
-            'n_head': 8, # mandatory
-            'dim_feedforward': 128,
-            'dropout_rate': 0.1,
-        }
-
-        exp_input_shape = 32, 20, 64
-        exp_output_shape = 32, 20, 64
-
-        self.block_test(transformer_encoder_layer, 
-                        model_config, 
-                        exp_input_shape,
-                        exp_output_shape)
-
-    def test_simple_dense_block(self):
-        model_config = {
-            'units': [128, 128], # mandatory
-            'n_classes': 10, # mandatory 
-            'name': 'simple_dense_block',
-            'activation': 'relu',
-            'dropout_rate': 0,
-            'kernel_regularizer': {'l1': 0, 'l2': 1e-3},
-        }
-
-        exp_input_shape = 32, 10, 128 # batch, time, feat
-        exp_output_shape = 32, 10, model_config['n_classes'] # batch, time, feat
-
-        self.block_test(simple_dense_block, 
-                        model_config, 
-                        exp_input_shape,
-                        exp_output_shape)
-
     def test_xception_block(self):
         model_config = {
             'filters' : 32,
@@ -149,6 +101,54 @@ class ModulesTest(tf.test.TestCase):
         exp_output_shape = 2, 60, 2048
 
         self.block_test(resnet50_block, 
+                        model_config, 
+                        exp_input_shape,
+                        exp_output_shape)
+
+    def test_bidirectional_GRU_block(self):
+        model_config = {
+            'units': [128, 128], # mandatory
+            'dropout_rate': 0.3,
+        }
+
+        exp_input_shape = 32, 10, 32, 8
+        exp_output_shape = 32, 10, 128
+
+        self.block_test(bidirectional_GRU_block, 
+                        model_config, 
+                        exp_input_shape,
+                        exp_output_shape)
+
+    def test_transformer_encoder_layer(self):
+        model_config = {
+            'd_model': 64, # mandatory
+            'n_head': 8, # mandatory
+            'dim_feedforward': 128,
+            'dropout_rate': 0.1,
+        }
+
+        exp_input_shape = 32, 20, 64
+        exp_output_shape = 32, 20, 64
+
+        self.block_test(transformer_encoder_layer, 
+                        model_config, 
+                        exp_input_shape,
+                        exp_output_shape)
+
+    def test_simple_dense_block(self):
+        model_config = {
+            'units': [128, 128], # mandatory
+            'n_classes': 10, # mandatory 
+            'name': 'simple_dense_block',
+            'activation': 'relu',
+            'dropout_rate': 0,
+            'kernel_regularizer': {'l1': 0, 'l2': 1e-3},
+        }
+
+        exp_input_shape = 32, 10, 128 # batch, time, feat
+        exp_output_shape = 32, 10, model_config['n_classes'] # batch, time, feat
+
+        self.block_test(simple_dense_block, 
                         model_config, 
                         exp_input_shape,
                         exp_output_shape)

--- a/modules_test.py
+++ b/modules_test.py
@@ -54,6 +54,23 @@ class ModulesTest(tf.test.TestCase):
                          exp_input_shape,
                          exp_output_shape)
 
+    def test_dense_net_block(self):
+        model_config = {
+            'growth_rate' : 6, # mandatory
+            'depth': 4, # mandatory
+            'strides': [2, 2], # mandatory
+            'bottleneck_ratio': 4,
+            'reduction_ratio': 0.5,
+        }
+
+        exp_input_shape = 2, 32, 32, 6
+        exp_output_shape = 2, 16, 16, 15
+
+        self.block_test(dense_net_block, 
+                        model_config, 
+                        exp_input_shape,
+                        exp_output_shape)
+
     def test_xception_block(self):
         model_config = {
             'filters' : 32,
@@ -66,22 +83,6 @@ class ModulesTest(tf.test.TestCase):
         exp_output_shape = 32, 60, 8192
 
         self.block_test(xception_block, 
-                        model_config, 
-                        exp_input_shape,
-                        exp_output_shape)
-
-    def test_dense_net_block(self):
-        model_config = {
-            'filters' : 32,
-            'name': 'dense_net_block',
-            'block_num': [6,12,24,16],
-            'kernel_regularizer': {'l1': 1e-3, 'l2': 0.}
-        }
-
-        exp_input_shape = 2, 300, 64, 3
-        exp_output_shape = 2, 60, 2040
-
-        self.block_test(dense_net_block, 
                         model_config, 
                         exp_input_shape,
                         exp_output_shape)

--- a/modules_test.py
+++ b/modules_test.py
@@ -21,6 +21,37 @@ class ModulesTest(tf.test.TestCase):
                         exp_input_shape,
                         exp_output_shape)
 
+    def test_res_basic_stage(self):
+         model_config = {
+             'depth': 2, # mandatory
+             'filters': 32, # mandatory (for res basic block)
+             'strides': 2, # mandatory (for res basic block)
+             'groups': 1, 
+         }
+
+         exp_input_shape = 32, 32, 32, 3
+         exp_output_shape = 32, 16, 16, 32
+
+         self.block_test(res_basic_stage,
+                         model_config,
+                         exp_input_shape,
+                         exp_output_shape)
+
+    def test_res_basic_block(self):
+         model_config = {
+             'filters': 32, # mandatory
+             'strides': 2, # mandatory
+             'groups': 1,
+         }
+
+         exp_input_shape = 32, 32, 32, 3
+         exp_output_shape = 32, 16, 16, 32
+
+         self.block_test(res_basic_block, 
+                         model_config, 
+                         exp_input_shape,
+                         exp_output_shape)
+
     def test_res_bottleneck_stage(self):
          model_config = {
              'depth': 2, # mandatory

--- a/modules_test.py
+++ b/modules_test.py
@@ -26,8 +26,8 @@ class ModulesTest(tf.test.TestCase):
              'depth': 2, # mandatory
              'filters': 32, # mandatory (for res bottleneck block)
              'strides': 2, # mandatory (for res bottleneck block)
-             'groups': 2, # mandatory (for res bottleneck block)
-             'bottleneck_ratio': 2, # mandatory (for res bottleneck block)
+             'groups': 1, 
+             'bottleneck_ratio': 2,
          }
 
          exp_input_shape = 32, 32, 32, 3
@@ -42,8 +42,8 @@ class ModulesTest(tf.test.TestCase):
          model_config = {
              'filters': 32, # mandatory
              'strides': 2, # mandatory
-             'groups': 2, # mandatory
-             'bottleneck_ratio': 2, # mandatory
+             'groups': 1,
+             'bottleneck_ratio': 2,
          }
 
          exp_input_shape = 32, 32, 32, 3

--- a/modules_test.py
+++ b/modules_test.py
@@ -153,6 +153,17 @@ class ModulesTest(tf.test.TestCase):
                         exp_input_shape,
                         exp_output_shape)
 
+    def test_identity_block(self):
+        model_config = {}
+
+        exp_input_shape = 32, 16, 16, 8
+        exp_output_shape = 32, 16, 16, 8
+
+        self.block_test(identity_block, 
+                        model_config, 
+                        exp_input_shape,
+                        exp_output_shape)
+
     def block_test(self, 
                    block_fn,
                    model_config: dict,
@@ -178,13 +189,5 @@ class ModulesTest(tf.test.TestCase):
 
 
 if __name__ == '__main__':
-    import argparse, sys
-    args = argparse.ArgumentParser()
-    args.add_argument('--gpus', type=str, default='-1')
-    config = args.parse_args()
-    os.environ['CUDA_VISIBLE_DEVICES'] = config.gpus
-    idx = sys.argv.index('--gpus')
-    for _ in range(2):
-        del sys.argv[idx]
     tf.test.main()
 

--- a/modules_test.py
+++ b/modules_test.py
@@ -150,7 +150,7 @@ class ModulesTest(tf.test.TestCase):
 
         # 2D inputs
         exp_input_shape = 32, 10, 32, 8
-        exp_output_shape = 32, 10, 32, 4
+        exp_output_shape = 32, 10, 128
 
         self.block_test(bidirectional_GRU_block, 
                         model_config, 

--- a/modules_test.py
+++ b/modules_test.py
@@ -21,6 +21,21 @@ class ModulesTest(tf.test.TestCase):
                         exp_input_shape,
                         exp_output_shape)
 
+    def test_another_conv_block(self):
+         model_config = {
+             'depth': 2, # mandatory
+             'filters': 32, # mandatory
+             'pool_size': 2, # mandatory 
+         }
+
+         exp_input_shape = 32, 32, 32, 3
+         exp_output_shape = 32, 16, 16, 32
+
+         self.block_test(another_conv_block,
+                         model_config,
+                         exp_input_shape,
+                         exp_output_shape)
+
     def test_res_basic_stage(self):
          model_config = {
              'depth': 2, # mandatory

--- a/modules_test.py
+++ b/modules_test.py
@@ -21,21 +21,38 @@ class ModulesTest(tf.test.TestCase):
                         exp_input_shape,
                         exp_output_shape)
 
-    def test_cond_conv_block(self):
-        model_config = {
-            'filters': [128, 128], # mandatory
-            'pool_size': [[4, 4], [1, 1]], # mandatory
-            'dropout_rate': 0.3,
-            'kernel_regularizer': {'l1': 1e-3, 'l2': 0.},
-        }
+    def test_res_bottleneck_stage(self):
+         model_config = {
+             'depth': 2, # mandatory
+             'filters': 32, # mandatory (for res bottleneck block)
+             'strides': 2, # mandatory (for res bottleneck block)
+             'groups': 2, # mandatory (for res bottleneck block)
+             'bottleneck_ratio': 2, # mandatory (for res bottleneck block)
+         }
 
-        exp_input_shape = 32, 32, 32, 3
-        exp_output_shape = 32, 8, 8, 128
+         exp_input_shape = 32, 32, 32, 3
+         exp_output_shape = 32, 16, 16, 32
 
-        self.block_test(cond_conv_block, 
-                        model_config, 
-                        exp_input_shape,
-                        exp_output_shape)
+         self.block_test(res_bottleneck_stage,
+                         model_config,
+                         exp_input_shape,
+                         exp_output_shape)
+
+    def test_res_bottleneck_block(self):
+         model_config = {
+             'filters': 32, # mandatory
+             'strides': 2, # mandatory
+             'groups': 2, # mandatory
+             'bottleneck_ratio': 2, # mandatory
+         }
+
+         exp_input_shape = 32, 32, 32, 3
+         exp_output_shape = 32, 16, 16, 32
+
+         self.block_test(res_bottleneck_block, 
+                         model_config, 
+                         exp_input_shape,
+                         exp_output_shape)
 
     def test_bidirectional_GRU_block(self):
         model_config = {

--- a/modules_test.py
+++ b/modules_test.py
@@ -139,8 +139,18 @@ class ModulesTest(tf.test.TestCase):
             'dropout_rate': 0.3,
         }
 
-        exp_input_shape = 32, 10, 32, 8
+        # 1D inputs
+        exp_input_shape = 32, 10, 32
         exp_output_shape = 32, 10, 128
+
+        self.block_test(bidirectional_GRU_block, 
+                        model_config, 
+                        exp_input_shape,
+                        exp_output_shape)
+
+        # 2D inputs
+        exp_input_shape = 32, 10, 32, 8
+        exp_output_shape = 32, 10, 32, 4
 
         self.block_test(bidirectional_GRU_block, 
                         model_config, 

--- a/modules_test.py
+++ b/modules_test.py
@@ -86,25 +86,6 @@ class ModulesTest(tf.test.TestCase):
                         exp_input_shape,
                         exp_output_shape)
 
-    def test_resnet50_block(self):
-        model_config = {
-            'filters': 32,
-            'name': 'resnet50_block',
-            'block_num': [3, 4, 6, 3],
-            'kernel_regularizer': {
-                'l1': 0,
-                'l2': 1e-3
-            }
-        }
-
-        exp_input_shape = 2, 300, 64, 3
-        exp_output_shape = 2, 60, 2048
-
-        self.block_test(resnet50_block, 
-                        model_config, 
-                        exp_input_shape,
-                        exp_output_shape)
-
     def test_bidirectional_GRU_block(self):
         model_config = {
             'units': [128, 128], # mandatory

--- a/params.py
+++ b/params.py
@@ -15,8 +15,7 @@ def get_param(known=None):
     args.add_argument('--config_mode', type=str, default='')
     args.add_argument('--doa_loss', type=str, default='MSE', 
                       choices=['MAE', 'MSE', 'MSLE', 'MMSE'])
-    args.add_argument('--model', type=str, default='seldnet', 
-                      choices=['seldnet', 'seldnet_v1'])
+    args.add_argument('--model', type=str, default='seldnet')
     args.add_argument('--model_config', type=str, default='')
     
     # training
@@ -27,11 +26,14 @@ def get_param(known=None):
     args.add_argument('--foa_aug', type=bool, default=True)
     args.add_argument('--epoch', type=int, default=1000)
     args.add_argument('--loss_weight', type=str, default='1,1000')
-    args.add_argument('--lr_patience', type=int, default=5, help='learning rate decay patience for plateau')
-    args.add_argument('--patience', type=int, default=10, help='early stop patience')
+    args.add_argument('--lr_patience', type=int, default=5, 
+                      help='learning rate decay patience for plateau')
+    args.add_argument('--patience', type=int, default=10, 
+                      help='early stop patience')
     args.add_argument('--freq_mask_size', type=int, default=16)
     args.add_argument('--time_mask_size', type=int, default=24)
-    args.add_argument('--loop_time', type=int, default=5, help='times of train dataset iter for an epoch')
+    args.add_argument('--loop_time', type=int, default=5, 
+                      help='times of train dataset iter for an epoch')
 
     # metric
     args.add_argument('--lad_doa_thresh', type=int, default=20)

--- a/params.py
+++ b/params.py
@@ -43,6 +43,7 @@ def get_param(known=None):
     # model config
     if len(config.model_config) == 0:
         config.model_config = config.model
+        config.model_config = os.path.splitext(config.model_config)[0]
     model_config_name = config.model_config
     model_config = model_config_name + '.json'
     model_config = os.path.join('./model_config', model_config)

--- a/params.py
+++ b/params.py
@@ -43,7 +43,7 @@ def get_param(known=None):
     # model config
     if len(config.model_config) == 0:
         config.model_config = config.model
-        config.model_config = os.path.splitext(config.model_config)[0]
+    config.model_config = os.path.splitext(config.model_config)[0]
     model_config_name = config.model_config
     model_config = model_config_name + '.json'
     model_config = os.path.join('./model_config', model_config)


### PR DESCRIPTION
1. res_bottleneck 복원 (이 모듈로 resent, efficientnet을 구현할 수 있음)
2. res_basic_block 추가 (3x3 두개짜리 res block)
3. dense_net_block 분해 (전체 densenet 구조가 아닌 그것을 이루는 블럭별로 나눔, 예시도 conv_temp.json로 추가)
4. resnet50 변환 (resnet50은 없어졌지만, resnet_gru.json이라는 이름으로 이전 코드에서 구현했던 것 그대로 구현하는 세팅을 제시함)
5. identity block 추가 (최대 5개가 있다고 할 때 4개, 3개 등도 가능하도록 연산이 없는 블럭을 추가)
6. another_conv_block 추가 (이는 1등 모델 구현에 사용하기 위해서)
7. conv_temporal이라는 모델 구조를 추가
어떻게 블럭화하여 사용할 수 있는지 json 예시들 첨부

이외에 GRU, attention은 2D든 1D든 받아 1D만 출력하도록 하였습니다.
Sepformer 기반 모듈은 추가적으로 시간나는대로 추가하겠습니다.
resolved: #87 