### PR TITLE
remove Namespace from model_config

### DIFF
--- a/models.py
+++ b/models.py
@@ -18,11 +18,11 @@ def seldnet(input_shape, model_config):
     # interprets model_config to an actual model
     inputs = Input(shape=input_shape[-3:])
 
-    x = getattr(modules, model_config.FIRST)(model_config.FIRST_ARGS)(inputs)
-    x = getattr(modules, model_config.SECOND)(model_config.SECOND_ARGS)(x)
+    x = getattr(modules, model_config['FIRST'])(model_config['FIRST_ARGS'])(inputs)
+    x = getattr(modules, model_config['SECOND'])(model_config['SECOND_ARGS'])(x)
 
-    sed = getattr(modules, model_config.SED)(model_config.SED_ARGS)(x)
-    doa = getattr(modules, model_config.DOA)(model_config.DOA_ARGS)(x)
+    sed = getattr(modules, model_config['SED'])(model_config['SED_ARGS'])(x)
+    doa = getattr(modules, model_config['DOA'])(model_config['DOA_ARGS'])(x)
 
     return tf.keras.Model(inputs=inputs, outputs=[sed, doa])
 
@@ -30,11 +30,11 @@ def seldnet(input_shape, model_config):
 def seldnet_v1(input_shape, model_config):
     inputs = Input(shape=input_shape[-3:])
 
-    x = getattr(modules, model_config.FIRST)(model_config.FIRST_ARGS)(inputs)
-    x = getattr(modules, model_config.SECOND)(model_config.SECOND_ARGS)(x)
+    x = getattr(modules, model_config['FIRST'])(model_config['FIRST_ARGS'])(inputs)
+    x = getattr(modules, model_config['SECOND'])(model_config['SECOND_ARGS'])(x)
 
-    sed = getattr(modules, model_config.SED)(model_config.SED_ARGS)(x)
-    doa = getattr(modules, model_config.DOA)(model_config.DOA_ARGS)(x)
+    sed = getattr(modules, model_config['SED'])(model_config['SED_ARGS'])(x)
+    doa = getattr(modules, model_config['DOA'])(model_config['DOA_ARGS'])(x)
 
     doa *= Concatenate()([sed] * 3)
     doa = tanh(doa) 
@@ -44,7 +44,6 @@ def seldnet_v1(input_shape, model_config):
 
 def conv_temporal(input_shape, model_config):
     inputs = Input(shape=input_shape[-3:])
-    model_config = vars(model_config) # namespace to dict
 
     filters = model_config.get('filters', 32)
     first_pool_size = model_config.get('first_pool_size', [5, 2])

--- a/params.py
+++ b/params.py
@@ -50,7 +50,7 @@ def get_param(known=None):
     
     if not os.path.exists(model_config):
         raise ValueError('Model config is not exists')
-    model_config = argparse.Namespace(**json.load(open(model_config,'rb')))
+    model_config = json.load(open(model_config,'rb'))
 
     config.name = f'{config.model}_{model_config_name}_{config.doa_loss}_{config.name}'
     config = get_config(config.name, config, mode=config.config_mode)


### PR DESCRIPTION
추후에 모델 생성할 때 model_config를 지금은 Namespace로 받고 있는데, 어짜피 지금도 json으로 dict를 받고, 다시 Namespace로 옮겼다가 사용하는 중이라서 dict로 받는게 더 좋지 않을까 해서 바꿔봤습니다.
현재 존재하는 seldnet, seldnet_v1, conv_temporal 세가지 모델로 에러없이 돌아가는 것을 확인하였습니다.

랜덤으로 생성할 때, Namespace, dict보다 더 나은 선택지가 있으면 같이 이야기해봐요.