### PR TITLE
Complexity 계산 (sampling 사전 작업)

### DIFF
--- a/complexity.py
+++ b/complexity.py
@@ -169,7 +169,27 @@ def dense_net_block_complexity(model_config, input_shape):
     return cx, shape
 
 
+# TODO: Sepformer
+# TODO: Xception
+
+
+def bidirectional_GRU_block_complexity(model_config, input_shape):
+    units_per_layer = model_config['units']
+
+    shape = input_shape
+    if len(shape) == 3:
+        shape = [shape[0], shape[1] * shape[2]]
+
+    cx = {}
+    for units in units_per_layer:
+        cx, shape = gru_complexity(shape, units, bi=True, prev_cx=cx)
+    return cx, shape
+
+
 '''            basic complexities            '''
+# TODO: Conv1D
+
+
 def conv2d_complexity(input_shape: list, 
                       filters,
                       kernel_size,

--- a/complexity.py
+++ b/complexity.py
@@ -27,6 +27,25 @@ def simple_conv_block_complexity(model_config, input_shape):
     return cx, shape
 
 
+def another_conv_block_complexity(model_config, input_shape):
+    filters = model_config['filters']
+    depth = model_config['depth']
+    pool_size = safe_tuple(model_config['pool_size'])
+
+    shape = input_shape
+    cx = {}
+
+    for i in range(depth):
+        cx, shape = conv2d_complexity(shape, filters, 3, prev_cx=cx)
+        cx, shape = conv2d_complexity(shape, filters, 3, prev_cx=cx)
+
+        if shape[-1] != filters:
+            cx, _ = conv2d_complexity(shape, filters, 1, prev_cx=cx)
+
+    cx, shape = pool2d_complexity(shape, pool_size, prev_cx=cx)
+    return cx, shape
+
+
 def res_bottleneck_block_complexity(model_config, input_shape):
     # mandatory parameters
     filters = model_config['filters']
@@ -58,7 +77,7 @@ def res_bottleneck_block_complexity(model_config, input_shape):
     return cx, output_shape
 
 
-''' basic complexities '''
+'''            basic complexities            '''
 def conv2d_complexity(input_shape: list, 
                       filters,
                       kernel_size,

--- a/complexity.py
+++ b/complexity.py
@@ -33,15 +33,16 @@ def another_conv_block_complexity(model_config, input_shape):
     depth = model_config['depth']
     pool_size = safe_tuple(model_config['pool_size'])
 
-    shape = input_shape
     cx = {}
 
     for i in range(depth):
+        shape = input_shape
         cx, shape = conv2d_complexity(shape, filters, 3, prev_cx=cx)
         cx, shape = conv2d_complexity(shape, filters, 3, prev_cx=cx)
 
         if input_shape[-1] != filters:
-            cx, _ = conv2d_complexity(shape, filters, 1, prev_cx=cx)
+            cx, _ = conv2d_complexity(input_shape, filters, 1, prev_cx=cx)
+        input_shape = shape
 
     cx, shape = pool2d_complexity(shape, pool_size, prev_cx=cx)
     return cx, shape
@@ -79,7 +80,7 @@ def res_basic_block_complexity(model_config, input_shape):
                                   groups=groups, prev_cx=cx)
 
     if input_shape[-1] != filters:
-        cx, _ = conv2d_complexity(shape, filters, 1, strides=strides, prev_cx=cx)
+        cx, _ = conv2d_complexity(input_shape, filters, 1, strides=strides, prev_cx=cx)
     return cx, shape
 
 
@@ -96,22 +97,22 @@ def res_bottleneck_block_complexity(model_config, input_shape):
 
     # calculate
     cx = {}
-    cx, output_shape = conv2d_complexity(input_shape, btn_size, 1, prev_cx=cx)
-    cx, output_shape = norm_complexity(output_shape, prev_cx=cx)
+    cx, shape = conv2d_complexity(input_shape, btn_size, 1, prev_cx=cx)
+    # cx, shape = norm_complexity(shape, prev_cx=cx)
 
-    cx, output_shape = conv2d_complexity(
-        output_shape, btn_size, 3, strides, groups, prev_cx=cx)
-    cx, output_shape = norm_complexity(output_shape, prev_cx=cx)
+    cx, shape = conv2d_complexity(
+        shape, btn_size, 3, strides, groups, prev_cx=cx)
+    # cx, shape = norm_complexity(shape, prev_cx=cx)
 
-    cx, output_shape = conv2d_complexity(output_shape, filters, 1, prev_cx=cx)
-    cx, output_shape = norm_complexity(output_shape, prev_cx=cx)
+    cx, shape = conv2d_complexity(shape, filters, 1, prev_cx=cx)
+    # cx, shape = norm_complexity(shape, prev_cx=cx)
 
     if strides != (1, 1) or input_shape[-1] != filters:
-        cx, output_shape = conv2d_complexity(input_shape, filters, 1, strides, 
+        cx, shape = conv2d_complexity(input_shape, filters, 1, strides, 
                                              prev_cx=cx)
-        cx, output_shape = norm_complexity(output_shape, prev_cx=cx)
+        # cx, shape = norm_complexity(shape, prev_cx=cx)
 
-    return cx, output_shape
+    return cx, shape
 
 
 '''            basic complexities            '''

--- a/complexity.py
+++ b/complexity.py
@@ -24,6 +24,7 @@ def simple_conv_block_complexity(model_config, input_shape):
     for i in range(len(filters)):
         cx, shape = conv2d_complexity(shape, filters[i], kernel_size=3, 
                                       prev_cx=cx)
+        cx, shape = norm_complexity(shape, prev_cx=cx)
         cx, shape = pool2d_complexity(shape, pool_size[i], prev_cx=cx)
     return cx, shape
 
@@ -37,7 +38,9 @@ def another_conv_block_complexity(model_config, input_shape):
 
     for i in range(depth):
         shape = input_shape
+        cx, shape = norm_complexity(shape, prev_cx=cx)
         cx, shape = conv2d_complexity(shape, filters, 3, prev_cx=cx)
+        cx, shape = norm_complexity(shape, prev_cx=cx)
         cx, shape = conv2d_complexity(shape, filters, 3, prev_cx=cx)
 
         if input_shape[-1] != filters:
@@ -76,11 +79,14 @@ def res_basic_block_complexity(model_config, input_shape):
 
     cx, shape = conv2d_complexity(shape, filters, 3, strides=strides,
                                   groups=groups, prev_cx=cx)
+    cx, shape = norm_complexity(shape, prev_cx=cx)
     cx, shape = conv2d_complexity(shape, filters, 3, 
                                   groups=groups, prev_cx=cx)
+    cx, shape = norm_complexity(shape, prev_cx=cx)
 
     if input_shape[-1] != filters:
         cx, _ = conv2d_complexity(input_shape, filters, 1, strides=strides, prev_cx=cx)
+        cx, _ = norm_complexity(shape, prev_cx=cx)
     return cx, shape
 
 
@@ -114,19 +120,19 @@ def res_bottleneck_block_complexity(model_config, input_shape):
     # calculate
     cx = {}
     cx, shape = conv2d_complexity(input_shape, btn_size, 1, prev_cx=cx)
-    # cx, shape = norm_complexity(shape, prev_cx=cx)
+    cx, shape = norm_complexity(shape, prev_cx=cx)
 
     cx, shape = conv2d_complexity(
         shape, btn_size, 3, strides, groups, prev_cx=cx)
-    # cx, shape = norm_complexity(shape, prev_cx=cx)
+    cx, shape = norm_complexity(shape, prev_cx=cx)
 
     cx, shape = conv2d_complexity(shape, filters, 1, prev_cx=cx)
-    # cx, shape = norm_complexity(shape, prev_cx=cx)
+    cx, shape = norm_complexity(shape, prev_cx=cx)
 
     if strides != (1, 1) or input_shape[-1] != filters:
         cx, shape = conv2d_complexity(input_shape, filters, 1, strides, 
                                              prev_cx=cx)
-        # cx, shape = norm_complexity(shape, prev_cx=cx)
+        cx, shape = norm_complexity(shape, prev_cx=cx)
 
     return cx, shape
 

--- a/complexity.py
+++ b/complexity.py
@@ -8,14 +8,16 @@
 # https://github.com/facebookresearch/pycls/blob/master/pycls/models/blocks.py
 from utils import dict_add
 
+
 def res_bottleneck_block_complexity(model_config, input_shape):
     # mandatory parameters
     filters = model_config['filters']
     strides = model_config['strides']
-    groups = model_config['groups']
-    bottleneck_ratio = model_config['bottleneck_ratio']
 
-    stries = safe_tuple(strides, 2)
+    groups = model_config.get('groups', 1)
+    bottleneck_ratio = model_config.get('bottleneck_ratio', 1)
+
+    strides = safe_tuple(strides, 2)
     btn_size = int(filters * bottleneck_ratio)
 
     # calculate
@@ -124,12 +126,11 @@ def gru_complexity(input_shape, units, use_bias=True,
     return complexity, output_shape
 
 
-# It only assume self attention
 def multi_head_attention_complexity(input_shape, num_heads, key_dim, 
-                                   value_dim=None,
-                                   use_bias=True, 
-                                   prev_cx=None):
-    
+                                    value_dim=None,
+                                    use_bias=True, 
+                                    prev_cx=None):
+    # It only assume self attention
     c = input_shape[-1]
     size = 1
     for s in input_shape[:-1]:

--- a/complexity.py
+++ b/complexity.py
@@ -84,6 +84,22 @@ def res_basic_block_complexity(model_config, input_shape):
     return cx, shape
 
 
+def res_bottleneck_stage_complexity(model_config, input_shape):
+    # mandatory parameters
+    depth = model_config['depth']
+    strides = model_config['strides']
+
+    model_config = copy.deepcopy(model_config)
+    shape = input_shape
+    total_cx = {}
+
+    for i in range(depth):
+        cx, shape = res_bottleneck_block_complexity(model_config, shape)
+        total_cx = dict_add(total_cx, cx)
+        model_config['strides'] = 1
+    return total_cx, shape
+
+
 def res_bottleneck_block_complexity(model_config, input_shape):
     # mandatory parameters
     filters = model_config['filters']

--- a/complexity.py
+++ b/complexity.py
@@ -309,7 +309,6 @@ def conv1d_complexity(input_shape: list,
     flops = kernel_size * c * filters * t
     params = kernel_size * c * filters
     if use_bias:
-        flops += filters 
         params += filters
 
     complexity = dict_add(
@@ -340,7 +339,6 @@ def conv2d_complexity(input_shape: list,
     flops = kernel * c * filters * h * w // groups
     params = kernel * c * filters // groups
     if use_bias:
-        flops += filters 
         params += filters
 
     complexity = dict_add(

--- a/complexity.py
+++ b/complexity.py
@@ -170,7 +170,7 @@ def dense_net_block_complexity(model_config, input_shape):
 
 
 # TODO: Sepformer
-# TODO: Xception
+# TODO: Xception - separableconv
 
 
 def bidirectional_GRU_block_complexity(model_config, input_shape):
@@ -209,6 +209,12 @@ def transformer_encoder_block_complexity(model_config, input_shape):
     cx, shape = norm_complexity(shape, prev_cx=cx)
 
     return cx, shape
+
+
+# TODO: simple_dense_block - n_classes issue must be fixed
+
+def identity_block_complexity(model_config, input_shape):
+    return {'flops': 0, 'params': 0}, input_shape
 
 
 '''            basic complexities            '''

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -76,6 +76,19 @@ class ComplexityTest(tf.test.TestCase):
                              model_config,
                              [32, 32, 3])
 
+    def test_dense_net_block_complexity(self):
+        model_config = {
+            'growth_rate': 8,
+            'depth': 3,
+            'strides': 2,
+            'bottleneck_ratio': 2,
+            'reduction_ratio': 0.5,
+        }
+        self.complexity_test(dense_net_block_complexity,
+                             dense_net_block,
+                             model_config,
+                             [32, 32, 3])
+
     def test_conv2d_complexity(self):
         target_cx = {'flops': 442384, 'params': 448}
         target_shape = [32, 32, 16]

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -109,6 +109,15 @@ class ComplexityTest(tf.test.TestCase):
                              model_config,
                              [32, 48])
 
+    def test_simple_dense_block_complexity(self):
+        model_config = {
+            'units': [32, 32]
+        }
+        self.complexity_test(simple_dense_block_complexity,
+                             simple_dense_block,
+                             model_config,
+                             [32, 48])
+
     def test_identity_block_complexity(self):
         model_config = {}
         self.complexity_test(identity_block_complexity,

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -89,6 +89,15 @@ class ComplexityTest(tf.test.TestCase):
                              model_config,
                              [32, 32, 3])
 
+    def test_bidirectional_GRU_block_complexity(self):
+        model_config = {
+            'units': [128, 128],
+        }
+        self.complexity_test(bidirectional_GRU_block_complexity,
+                             bidirectional_GRU_block,
+                             model_config,
+                             [32, 32, 3])
+
     def test_conv2d_complexity(self):
         target_cx = {'flops': 442384, 'params': 448}
         target_shape = [32, 32, 16]
@@ -220,9 +229,9 @@ class ComplexityTest(tf.test.TestCase):
         cx, output_shape = complexity_fn(model_config, exp_input_shape)
 
         # TODO: count ops
-        params = [p for p in model.weights]
         self.assertEquals(cx['params'], 
-                          sum([K.count_params(p) for p in model.trainable_weights]))
+                          sum([K.count_params(p) 
+                               for p in model.trainable_weights]))
         self.assertEquals(tuple(output_shape), model.output_shape[1:])
 
 

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -51,6 +51,19 @@ class ComplexityTest(tf.test.TestCase):
                              model_config,
                              [32, 32, 3])
 
+    def test_res_bottleneck_stage_complexity(self):
+        model_config = {
+            'depth': 4,
+            'strides': 2,
+            'filters': 24,
+            'groups': 2,
+            'bottleneck_ratio': 2
+        }
+        self.complexity_test(res_bottleneck_stage_complexity,
+                             res_bottleneck_stage,
+                             model_config,
+                             [32, 32, 16])
+
     def test_res_bottleneck_block_complexity(self):
         model_config = {
             'filters': 32,

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -89,6 +89,17 @@ class ComplexityTest(tf.test.TestCase):
                              model_config,
                              [32, 32, 3])
 
+    def test_sepformer_block_complexity(self):
+        model_config = {
+            'n_head': 8,
+            'ff_multiplier': 4,
+            'kernel_size': 3,
+        }
+        self.complexity_test(sepformer_block_complexity,
+                             sepformer_block,
+                             model_config,
+                             [32, 32, 3])
+
     def test_xception_block_complexity(self):
         model_config = {
             'filters': 32,

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -207,9 +207,9 @@ class ComplexityTest(tf.test.TestCase):
         cx, output_shape = complexity_fn(model_config, exp_input_shape)
 
         # TODO: count ops
-        params = [p for p in model.weights if p.name.startswith('conv')]
+        params = [p for p in model.weights]
         self.assertEquals(cx['params'], 
-                          sum([K.count_params(p) for p in params]))
+                          sum([K.count_params(p) for p in model.trainable_weights]))
         self.assertEquals(tuple(output_shape), model.output_shape[1:])
 
 

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -7,6 +7,16 @@ class ComplexityTest(tf.test.TestCase):
     def setUp(self):
         self.prev_cx = {'flops': 456, 'params': 123}
 
+    def test_simple_conv_block_complexity(self):
+        model_config = {
+            'filters': [32, 32],
+            'pool_size': [2, 2],
+        }
+        input_shape = [32, 32, 16]
+        self.assertEqual(
+            simple_conv_block_complexity(model_config, input_shape),
+            ({'flops': 7077952, 'params': 13888}, [8, 8, 32]))
+
     def test_res_bottleneck_block_complexity(self):
         model_config = {
             'filters': 32,

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -17,6 +17,17 @@ class ComplexityTest(tf.test.TestCase):
             simple_conv_block_complexity(model_config, input_shape),
             ({'flops': 7077952, 'params': 13888}, [8, 8, 32]))
 
+    def test_another_conv_block_complexity(self):
+        model_config = {
+            'filters': 32,
+            'depth': 3,
+            'pool_size': [2, 1],
+        }
+        input_shape = [32, 32, 16]
+        self.assertEqual(
+            another_conv_block_complexity(model_config, input_shape),
+            ({'flops': 51904704, 'params': 50880}, [16, 32, 32]))
+
     def test_res_bottleneck_block_complexity(self):
         model_config = {
             'filters': 32,

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -109,6 +109,13 @@ class ComplexityTest(tf.test.TestCase):
                              model_config,
                              [32, 48])
 
+    def test_identity_block_complexity(self):
+        model_config = {}
+        self.complexity_test(identity_block_complexity,
+                             identity_block,
+                             model_config,
+                             [32, 32, 48])
+
     def test_conv2d_complexity(self):
         target_cx = {'flops': 442384, 'params': 448}
         target_shape = [32, 32, 16]

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -98,6 +98,17 @@ class ComplexityTest(tf.test.TestCase):
                              model_config,
                              [32, 32, 3])
 
+    def test_transformer_encoder_block_complexity(self):
+        model_config = {
+            'n_head': 4,
+            'ff_multiplier': 2,
+            'kernel_size': 3,
+        }
+        self.complexity_test(transformer_encoder_block_complexity,
+                             transformer_encoder_block,
+                             model_config,
+                             [32, 48])
+
     def test_conv2d_complexity(self):
         target_cx = {'flops': 442384, 'params': 448}
         target_shape = [32, 32, 16]

--- a/complexity_test.py
+++ b/complexity_test.py
@@ -26,7 +26,30 @@ class ComplexityTest(tf.test.TestCase):
         input_shape = [32, 32, 16]
         self.assertEqual(
             another_conv_block_complexity(model_config, input_shape),
-            ({'flops': 51904704, 'params': 50880}, [16, 32, 32]))
+            ({'flops': 55050528, 'params': 54048}, [16, 32, 32]))
+
+    def test_res_basic_stage_complexity(self):
+        model_config = {
+            'depth': 4,
+            'strides': 2,
+            'filters': 24,
+            'groups': 2,
+        }
+        input_shape = [32, 32, 16]
+        self.assertEqual(
+            res_basic_stage_complexity(model_config, input_shape),
+            ({'flops': 5124312, 'params': 20664}, [16, 16, 24]))
+
+    def test_res_basic_block_complexity(self):
+        model_config = {
+            'strides': 2,
+            'filters': 24,
+            'groups': 2,
+        }
+        input_shape = [32, 32, 16]
+        self.assertEqual(
+            res_basic_block_complexity(model_config, input_shape),
+            ({'flops': 1142856, 'params': 4968}, [16, 16, 24]))
 
     def test_res_bottleneck_block_complexity(self):
         model_config = {

--- a/models.py
+++ b/models.py
@@ -15,6 +15,8 @@ You should not define modules nor layers here.
 
 
 def seldnet(input_shape, model_config):
+    n_classes = model_config.get('n_classes', 14)
+
     # interprets model_config to an actual model
     inputs = Input(shape=input_shape[-3:])
 
@@ -22,19 +24,25 @@ def seldnet(input_shape, model_config):
     x = getattr(modules, model_config['SECOND'])(model_config['SECOND_ARGS'])(x)
 
     sed = getattr(modules, model_config['SED'])(model_config['SED_ARGS'])(x)
+    sed = Dense(n_classes, activation='sigmoid', name='sed_out')(sed)
     doa = getattr(modules, model_config['DOA'])(model_config['DOA_ARGS'])(x)
+    doa = Dense(3*n_classes, activation='tanh', name='doa_out')(doa)
 
     return tf.keras.Model(inputs=inputs, outputs=[sed, doa])
 
 
 def seldnet_v1(input_shape, model_config):
+    n_classes = model_config.get('n_classes', 14)
+
     inputs = Input(shape=input_shape[-3:])
 
     x = getattr(modules, model_config['FIRST'])(model_config['FIRST_ARGS'])(inputs)
     x = getattr(modules, model_config['SECOND'])(model_config['SECOND_ARGS'])(x)
 
     sed = getattr(modules, model_config['SED'])(model_config['SED_ARGS'])(x)
+    sed = Dense(n_classes, activation='sigmoid', name='sed_out')(sed)
     doa = getattr(modules, model_config['DOA'])(model_config['DOA_ARGS'])(x)
+    doa = Dense(3*n_classes, activation='tanh', name='doa_out')(doa)
 
     doa *= Concatenate()([sed] * 3)
     doa = tanh(doa) 
@@ -43,12 +51,15 @@ def seldnet_v1(input_shape, model_config):
     
 
 def conv_temporal(input_shape, model_config):
-    inputs = Input(shape=input_shape[-3:])
-
     filters = model_config.get('filters', 32)
+    first_kernel_size = model_config.get('first_kernel_size', 7)
     first_pool_size = model_config.get('first_pool_size', [5, 2])
+    n_classes = model_config.get('n_classes', 14)
+
+    inputs = Input(shape=input_shape[-3:])
     
-    x = layers.conv2d_bn(filters, 7, padding='same', activation='relu')(inputs)
+    x = layers.conv2d_bn(filters, first_kernel_size, padding='same', 
+                         activation='relu')(inputs)
     x = MaxPooling2D(first_pool_size, padding='same')(x)
 
     blocks = [key for key in model_config.keys()
@@ -59,7 +70,9 @@ def conv_temporal(input_shape, model_config):
         x = getattr(modules, model_config[block])(model_config[f'{block}_ARGS'])(x)
 
     sed = getattr(modules, model_config['SED'])(model_config['SED_ARGS'])(x)
+    sed = Dense(n_classes, activation='sigmoid', name='sed_out')(sed)
     doa = getattr(modules, model_config['DOA'])(model_config['DOA_ARGS'])(x)
+    doa = Dense(3*n_classes, activation='tanh', name='doa_out')(doa)
 
     return tf.keras.Model(inputs=inputs, outputs=[sed, doa])
 

--- a/modules.py
+++ b/modules.py
@@ -246,7 +246,6 @@ def sepformer_block(model_config: dict):
     return _sepformer_block
     
 
-"""            BLOCKS WITH 1D OUTPUTS            """
 def xception_block(model_config: dict):
     filters = model_config['filters']
     block_num = model_config['block_num']
@@ -304,11 +303,11 @@ def xception_block(model_config: dict):
 
         x = _sepconv_block(x, filters * 48, 'relu')
         x = _sepconv_block(x, filters * 64, 'relu')
-        x = Reshape((-1, x.shape[-2]*x.shape[-1]))(x)
         return x
     return _xception_net_block
 
 
+"""            BLOCKS WITH 1D OUTPUTS            """
 def bidirectional_GRU_block(model_config: dict):
     # mandatory parameters
     units_per_layer = model_config['units']

--- a/modules.py
+++ b/modules.py
@@ -366,10 +366,8 @@ def simple_dense_block(model_config: dict):
     # assumes 1D inputs
     # mandatory parameters
     units_per_layer = model_config['units']
-    n_classes = model_config['n_classes']
 
-    name = model_config.get('name', None)
-    activation = model_config.get('activation', None)
+    activation = model_config.get('dense_activation', None)
     dropout_rate = model_config.get('dropout_rate', 0)
     kernel_regularizer = tf.keras.regularizers.l1_l2(
         **model_config.get('kernel_regularizer', {'l1': 0., 'l2': 0.}))
@@ -380,10 +378,9 @@ def simple_dense_block(model_config: dict):
         for units in units_per_layer:
             x = TimeDistributed(
                 Dense(units, kernel_regularizer=kernel_regularizer))(x)
+            if activation:
+                x = Activation(activation)(x)
             x = Dropout(dropout_rate)(x)
-        x = TimeDistributed(
-            Dense(n_classes, activation=activation, name=name,
-                  kernel_regularizer=kernel_regularizer))(x) 
         return x
 
     return dense_block

--- a/modules.py
+++ b/modules.py
@@ -201,7 +201,7 @@ def dense_net_block(model_config: dict):
 
 
 def sepformer_block(model_config: dict):
-    # mandatory parameters (for transformer_encoder_layer)
+    # mandatory parameters (for transformer_encoder_block)
     # 'n_head', 'ff_multiplier', 'kernel_size'
 
     pos_encoding = model_config.get('pos_encoding', None)
@@ -227,7 +227,7 @@ def sepformer_block(model_config: dict):
         intra = tf.reshape(intra, [-1, time, freq])
         if pos_encoding:
             intra += pos_encoding(intra.shape)(intra)
-        intra = transformer_encoder_layer(model_config)(intra)
+        intra = transformer_encoder_block(model_config)(intra)
         intra = tf.reshape(intra, [-1, chan, time, freq])
         intra = tf.transpose(intra, [0, 2, 3, 1])
         intra = LayerNormalization()(intra) + x
@@ -236,7 +236,7 @@ def sepformer_block(model_config: dict):
         inter = tf.reshape(inter, [-1, chan, freq])
         if pos_encoding:
             inter += pos_encoding(inter.shape)(inter)
-        inter = transformer_encoder_layer(model_config)(inter)
+        inter = transformer_encoder_block(model_config)(inter)
         inter = tf.reshape(inter, [-1, time, chan, freq])
         inter = tf.transpose(inter, [0, 1, 3, 2])
         inter = LayerNormalization()(inter) + intra
@@ -330,7 +330,7 @@ def bidirectional_GRU_block(model_config: dict):
     return GRU_block
 
 
-def transformer_encoder_layer(model_config: dict):
+def transformer_encoder_block(model_config: dict):
     # mandatory parameters
     n_head = model_config['n_head']
     # multiplier for feed forward layer

--- a/modules_test.py
+++ b/modules_test.py
@@ -173,7 +173,7 @@ class ModulesTest(tf.test.TestCase):
                         exp_input_shape,
                         exp_output_shape)
 
-    def test_transformer_encoder_layer(self):
+    def test_transformer_encoder_block(self):
         model_config = {
             'n_head': 8, # mandatory
             'ff_multiplier': 128, # mandatory
@@ -184,7 +184,7 @@ class ModulesTest(tf.test.TestCase):
         exp_input_shape = 32, 20, 64
         exp_output_shape = 32, 20, 64
 
-        self.block_test(transformer_encoder_layer, 
+        self.block_test(transformer_encoder_block, 
                         model_config, 
                         exp_input_shape,
                         exp_output_shape)
@@ -192,15 +192,12 @@ class ModulesTest(tf.test.TestCase):
     def test_simple_dense_block(self):
         model_config = {
             'units': [128, 128], # mandatory
-            'n_classes': 10, # mandatory 
-            'name': 'simple_dense_block',
-            'activation': 'relu',
+            'dense_activation': 'relu',
             'dropout_rate': 0,
             'kernel_regularizer': {'l1': 0, 'l2': 1e-3},
         }
-
-        exp_input_shape = 32, 10, 128 # batch, time, feat
-        exp_output_shape = 32, 10, model_config['n_classes'] # batch, time, feat
+        exp_input_shape = 32, 10, 64
+        exp_output_shape = 32, 10, 128
 
         self.block_test(simple_dense_block, 
                         model_config, 


### PR DESCRIPTION
sampler를 수정해서 올리려고 했는데, 그 전에 params, flops 계산 파트를 같이 묶어서 샘플링하는 기본 뼈대를 공유하는게
좋을 것 같아서 complexity 먼저 구현해서 올립니다. 현재 구현된 모든 모듈들 모두 구하였습니다.
제 기준으로는 옮기는게 특별히 어렵지는 않아서, 추가로 모듈을 추가하더라도 어렵지 않으리라 생각됩니다.

제대로 된 테스트를 위해, complexity func의 args와 실제 모듈 생성할 때 쓰이는 args가 동일하도록 하였습니다.
그리고 실제로 해당 config로 모델을 만들어서, 실제 파라미터 개수 (trainable weights)와 output shape이 동일한지 테스트하도록
테스트코드를 작성하였습니다.
그래서 나중에 모듈에 변경이 생기더라도, 실제 모듈을 생성하는 함수를 직접 이용하여 비교하기 때문에 complexity 계산도
잘 되고 있는지 확인이 수월할 것이라 생각됩니다.

추가로 n_classes를 simple_dense_block에서 제외하는것을 다른 풀리퀘에 올렸는데, complexity구하려니까,
이걸 먼저 업데이트해야할 것 같아 같이 업데이트하였습니다.

sampler의 경우 해당 업데이트가 확정되는대로 그에 맞춰서 실제로 바로 학습에 사용할 수 있도록 올리도록 하겠습니다.