### PR TITLE
Add Mother Stage (block)

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -377,7 +377,7 @@ def mother_block(model_config: dict):
             for i in range(len(connect2)):
                 if connect2[i] == 1:
                     skip = outputs[i]
-                    if connect2[-1] == 1 and i < 2:
+                    if connect2[-1] == 1 and tuple(strides) != (1, 1) and i < 2:
                         # connect with strided outputs
                         skip = Conv2D(skip.shape[-1], 1, strides=strides)(skip)
                     out.append(skip)

--- a/modules.py
+++ b/modules.py
@@ -12,6 +12,19 @@ Use only custom layers or predefined
 """
 
 """            STAGES            """
+def mother_stage(model_config: dict):
+    depth = model_config['depth']
+    strides = model_config['strides']
+    model_config = copy.deepcopy(model_config)
+
+    def stage(x):
+        for i in range(depth):
+            x = mother_block(model_config)(x)
+            model_config['strides'] = (1, 1)
+        return x
+    return stage
+
+
 def simple_conv_stage(model_config: dict):
     '''
     essential configs
@@ -273,6 +286,107 @@ def conformer_encoder_stage(model_config: dict):
 
 
 """            BLOCKS WITH 2D OUTPUTS            """
+def mother_block(model_config: dict):
+    filters0 = model_config['filters0'] # 0 if skipped
+    filters1 = model_config['filters1'] # 0 if skipped
+    filters2 = model_config['filters2'] # 0 if skipped
+    kernel_size0 = model_config['kernel_size0'] # 0 if skipped
+    kernel_size1 = model_config['kernel_size1'] # 0 if skipped
+    kernel_size2 = model_config['kernel_size2'] # 0 if skipped
+    connect0 = model_config['connect0'] # len of 1 (0: input)
+    connect1 = model_config['connect1'] # len of 2 (0: input, 1: out0)
+    connect2 = model_config['connect2'] # len of 3 (0: input, 1: out0, 2: out1)
+
+    strides = safe_tuple(model_config.get('strides', (1, 1)))
+    activation = model_config.get('activation', 'relu')
+
+    if (filters0 == 0) != (kernel_size0 == 0):
+        raise ValueError('0) skipped layer must have 0 filters, 0 kernel size')
+    if (filters1 == 0) != (kernel_size1 == 0):
+        raise ValueError('1) skipped layer must have 0 filters, 0 kernel size')
+    if (filters2 == 0) != (kernel_size2 == 0):
+        raise ValueError('2) skipped layer must have 0 filters, 0 kernel size')
+
+    if filters0 == 0 and max(connect1[1], connect2[1]):
+        raise ValueError('cannot link skipped layer (first layer)')
+    if filters1 == 0 and connect2[2] > 0:
+        raise ValueError('cannot link skipped layer (second layer)')
+
+    if (filters0 != 0) + sum(connect0) == 0:
+        raise ValueError('cannot pass zero inputs to the second layer')
+    if (filters1 != 0) + sum(connect1) == 0:
+        raise ValueError('cannot pass zero inputs to the third layer')
+    if (filters2 != 0) + sum(connect2) == 0:
+        raise ValueError('cannot pass zero inputs to the final output')
+
+    if filters1 == 0 and tuple(strides) != (1, 1):
+        raise ValueError('if strides are set, the second layer must be active')
+
+    def block(inputs):
+        outputs = [inputs]
+
+        # first layer
+        if filters0 > 0:
+            out = Conv2D(filters0, kernel_size0, padding='same')(outputs[-1])
+            out = BatchNormalization()(out)
+            if connect0[0] == 1:
+                skip = outputs[-1]
+                if skip.shape[-3:] != out.shape[-3:]:
+                    skip = Conv2D(filters0, 1)(skip)
+                out += BatchNormalization()(skip)
+            out = Activation(activation)(out)
+        else:
+            out = outputs[-1]
+        outputs.append(out)
+
+        # second layer (apply strides)
+        if filters1 > 0:
+            out = Conv2D(filters1, kernel_size1, padding='same',
+                         strides=strides)(outputs[-1])
+            out = BatchNormalization()(out)
+            for i in range(len(connect1)):
+                if connect1[i] == 1:
+                    skip = outputs[i]
+                    if skip.shape[-3:] != out.shape[-3:]:
+                        skip = Conv2D(filters1, 1, strides=strides)(skip)
+                    out += BatchNormalization()(skip)
+            out = Activation(activation)(out)
+        else:
+            out = []
+            for i in range(len(connect1)):
+                if connect1[i] == 1:
+                    out.append(outputs[i])
+            out = tf.concat(out, axis=-1)
+        outputs.append(out)
+
+        # third layer
+        if filters2 > 0:
+            out = Conv2D(filters2, kernel_size2, padding='same')(outputs[-1])
+            out = BatchNormalization()(out)
+            for i in range(len(connect2)):
+                if connect2[i] == 1:
+                    skip = outputs[i]
+                    if skip.shape[-3:] != out.shape[-3:]:
+                        skip = Conv2D(
+                            filters2, 1, 
+                            strides=(1, 1) if i == 2 else strides)(skip)
+                    out += BatchNormalization()(skip)
+            out = Activation(activation)(out)
+        else:
+            out = []
+            for i in range(len(connect2)):
+                if connect2[i] == 1:
+                    skip = outputs[i]
+                    if connect2[-1] == 1 and i < 2:
+                        # connect with strided outputs
+                        skip = Conv2D(skip.shape[-1], 1, strides=strides)(skip)
+                    out.append(skip)
+            out = tf.concat(out, axis=-1)
+
+        return out
+    return block
+
+
 def simple_conv_block(model_config: dict):
     # mandatory parameters
     filters = model_config['filters']

--- a/modules_test.py
+++ b/modules_test.py
@@ -5,6 +5,30 @@ from modules import *
 
 
 class ModulesTest(tf.test.TestCase):
+    def test_mother_stage(self):
+        model_config = {
+            'depth': 2,
+            'filters0': 3,
+            'filters1': 3,
+            'filters2': 6,
+            'kernel_size0': 1,
+            'kernel_size1': 3,
+            'kernel_size2': 1,
+            'connect0': [0],
+            'connect1': [0, 0],
+            'connect2': [1, 0, 0],
+            'strides': [2, 2],
+            'activation': 'relu',
+        }
+
+        exp_input_shape = 32, 32, 32, 3
+        exp_output_shape = 32, 16, 16, 6
+
+        self.block_test(mother_stage, 
+                        model_config, 
+                        exp_input_shape,
+                        exp_output_shape)
+
     def test_simple_conv_stage(self):
         model_config = {
             'filters': 128,
@@ -183,6 +207,29 @@ class ModulesTest(tf.test.TestCase):
         exp_output_shape = 32, 100, 64 # batch, time, feat
     
         self.block_test(conformer_encoder_stage, 
+                        model_config, 
+                        exp_input_shape,
+                        exp_output_shape)
+
+    def test_mother_block(self):
+        model_config = {
+            'filters0': 6,
+            'filters1': 8,
+            'filters2': 0,
+            'kernel_size0': 3,
+            'kernel_size1': 3,
+            'kernel_size2': 0,
+            'connect0': [0],
+            'connect1': [0, 1],
+            'connect2': [1, 0, 1],
+            'strides': [1, 2],
+            'activation': 'relu',
+        }
+
+        exp_input_shape = 32, 32, 32, 3
+        exp_output_shape = 32, 32, 16, 11
+
+        self.block_test(mother_block, 
                         model_config, 
                         exp_input_shape,
                         exp_output_shape)
@@ -415,6 +462,7 @@ class ModulesTest(tf.test.TestCase):
         inputs = tf.keras.layers.Input(exp_input_shape[1:])
         outputs = block_fn(model_config)(inputs)
         model = tf.keras.Model(inputs=inputs, outputs=outputs)
+        model.summary()
 
         x = tf.zeros(exp_input_shape)
         y = model(x)

--- a/modules_test.py
+++ b/modules_test.py
@@ -462,7 +462,6 @@ class ModulesTest(tf.test.TestCase):
         inputs = tf.keras.layers.Input(exp_input_shape[1:])
         outputs = block_fn(model_config)(inputs)
         model = tf.keras.Model(inputs=inputs, outputs=outputs)
-        model.summary()
 
         x = tf.zeros(exp_input_shape)
         y = model(x)


### PR DESCRIPTION
여러가지 stage를 표현할 수 있는 mother stage를 만들어봤습니다.
기존에는 dilation rate, groups 등이 있었는데, groups는 저번에 성능차이가 없다는 지적이 있어서 일단 빼서 구현해놓았습니다.

3개의 레이어로 구성되어 있으며, 각 레이어별로 filters, kernel_size를 갖습니다.
그외에 connect0 ~ connect2은 리스트로 입력을 받으며, 
0번째는 처음 입력, 1번째는 첫번째 레이어의 output, 2번째는 두번째 레이어의 output입니다.
strides는 가운데만 적용되었고, activation은 default로 relu로 설정되어 있습니다.

여러 config가 같은 모델에 매핑되지 않도록 여러가지 강제조항들을 적용하였습니다.
먼저 특정 레이어가 무시된다면 filters, kernel_size가 모두 0으로 되어야 합니다.
그리고 특정 레이어가 무시되었다면, 무시된 레이어의 output은 이후 레이어가 skip connection으로 연결할 수 없습니다. (input * 2 형태가 되는 것을 방지하기 위해)
strides는 가운데 레이어를 위한 수치이기 때문에 가운데 레이어가 무시되면 strides 또한 (1, 1)이 되어야 합니다.

그 외에 레이어가 무시되었는데 skip connection 또한 아무것도 없어 0을 뒤로 내보내는 일이 없도록 강제하였습니다.
특정 레이어는 무시되고 skip connection끼리만 연결되는 경우, 기본적으로 concat을 이용하며, 두번째 레이어가 살아 있고, strides가 (1, 1)이 아닌 경우 skip connection끼리 자신의 채널에 맞고, strides도 맞도록 한 후에 concat을 합니다.

다양한 리뷰 부탁드립니다.